### PR TITLE
Changed `_format` and `_pretty` params to be optional.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ doc/api/
 
 .flutter-plugins
 .flutter-plugins-dependencies
+
+.idea

--- a/lib/dstu2/fhir_request.dart
+++ b/lib/dstu2/fhir_request.dart
@@ -46,15 +46,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -107,15 +106,14 @@ class FhirRequest with _$FhirRequest {
     required FhirId vid,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -159,15 +157,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -211,15 +208,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -270,15 +266,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -322,15 +317,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -379,15 +373,14 @@ class FhirRequest with _$FhirRequest {
     required Dstu2ResourceType type,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -435,15 +428,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -487,15 +479,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -542,15 +533,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -597,15 +587,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -668,15 +657,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -749,15 +737,14 @@ class FhirRequest with _$FhirRequest {
     required Dstu2ResourceType type,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -826,15 +813,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -900,15 +886,14 @@ class FhirRequest with _$FhirRequest {
     String? fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -1586,13 +1571,13 @@ class FhirRequest with _$FhirRequest {
       orElse: () => '');
 
   /// specifies the format
-  String _format({bool join = false}) => maybeMap(
+  String _format({bool join = false}) => format == null ? '' : maybeMap(
       capabilities: (FhirCapabilitiesRequest request) =>
           _encodeParam('_format=${request.format}'),
       orElse: () => _encodeParam('_format=$format', join: join));
 
   /// assigns if you want it pretty
-  String _pretty({bool join = true}) =>
+  String _pretty({bool join = true}) => pretty == null ? '' :
       _encodeParam('_pretty=$pretty', join: join);
 
   /// assigns if you want the summary

--- a/lib/dstu2/fhir_request.dart
+++ b/lib/dstu2/fhir_request.dart
@@ -1571,14 +1571,16 @@ class FhirRequest with _$FhirRequest {
       orElse: () => '');
 
   /// specifies the format
-  String _format({bool join = false}) => format == null ? '' : maybeMap(
-      capabilities: (FhirCapabilitiesRequest request) =>
-          _encodeParam('_format=${request.format}'),
-      orElse: () => _encodeParam('_format=$format', join: join));
+  String _format({bool join = false}) => format == null
+      ? ''
+      : maybeMap(
+          capabilities: (FhirCapabilitiesRequest request) =>
+              _encodeParam('_format=${request.format}'),
+          orElse: () => _encodeParam('_format=$format', join: join));
 
   /// assigns if you want it pretty
-  String _pretty({bool join = true}) => pretty == null ? '' :
-      _encodeParam('_pretty=$pretty', join: join);
+  String _pretty({bool join = true}) =>
+      pretty == null ? '' : _encodeParam('_pretty=$pretty', join: join);
 
   /// assigns if you want the summary
   String _summary({bool join = true}) => summary != Summary.none
@@ -1764,7 +1766,7 @@ class FhirRequest with _$FhirRequest {
     if (_errorCodes.containsKey(result.statusCode)) {
       return OperationOutcome(issue: <OperationOutcomeIssue>[
         OperationOutcomeIssue(
-            severity: IssueSeverity.error,
+          severity: IssueSeverity.error,
           code: FhirCode('unknown'),
           details: const CodeableConcept(
               text: 'Failed to complete a restful request.\n'
@@ -1781,7 +1783,7 @@ class FhirRequest with _$FhirRequest {
         if (result.statusCode == 200 || result.statusCode == 201) {
           return OperationOutcome(issue: <OperationOutcomeIssue>[
             OperationOutcomeIssue(
-                 severity: IssueSeverity.information,
+                severity: IssueSeverity.information,
                 code: FhirCode('informational'),
                 diagnostics: 'Your request succeeded with a status of '
                     '${result.statusCode}\n, but the request result did not have '
@@ -1800,7 +1802,7 @@ class FhirRequest with _$FhirRequest {
         } else {
           return OperationOutcome(issue: <OperationOutcomeIssue>[
             OperationOutcomeIssue(
-             severity: IssueSeverity.information,
+                severity: IssueSeverity.information,
                 code: FhirCode('informational'),
                 diagnostics: 'Your request succeeded with a status of '
                     '${result.statusCode}\n, but the request result did not have '
@@ -1822,7 +1824,7 @@ class FhirRequest with _$FhirRequest {
         if (body?['resourceType'] == null) {
           return OperationOutcome(issue: <OperationOutcomeIssue>[
             OperationOutcomeIssue(
-               severity: IssueSeverity.error,
+              severity: IssueSeverity.error,
               code: FhirCode('unknown'),
               details: const CodeableConcept(
                   text:
@@ -1842,7 +1844,7 @@ class FhirRequest with _$FhirRequest {
                 if (operationOutcome.issue.isNotEmpty)
                   ...operationOutcome.issue,
                 OperationOutcomeIssue(
-         severity: IssueSeverity.error,
+                    severity: IssueSeverity.error,
                     code: FhirCode('unknown'),
                     diagnostics:
                         'Status: ${body?['status']}\nMessage: ${body?['message']}\n'),
@@ -1856,7 +1858,7 @@ class FhirRequest with _$FhirRequest {
           if (newResource.resourceType == null) {
             return OperationOutcome(issue: <OperationOutcomeIssue>[
               OperationOutcomeIssue(
-                   severity: IssueSeverity.error,
+                severity: IssueSeverity.error,
                 code: FhirCode('unknown'),
                 details: const CodeableConcept(
                     text: 'Request was made and seemed to return a Resource,\n'
@@ -1880,7 +1882,7 @@ class FhirRequest with _$FhirRequest {
   OperationOutcome _operationOutcome(String issue, {String? diagnostics}) =>
       OperationOutcome(issue: <OperationOutcomeIssue>[
         OperationOutcomeIssue(
-           severity: IssueSeverity.error,
+          severity: IssueSeverity.error,
           code: FhirCode('value'),
           details: CodeableConcept(text: issue),
           diagnostics: diagnostics,

--- a/lib/dstu2/fhir_request.freezed.dart
+++ b/lib/dstu2/fhir_request.freezed.dart
@@ -59,15 +59,14 @@ mixin _$FhirRequest {
   Uri get base => throw _privateConstructorUsedError;
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty => throw _privateConstructorUsedError;
+  bool? get pretty => throw _privateConstructorUsedError;
 
   /// [summary] - do you want the result to be a summary
   Summary get summary => throw _privateConstructorUsedError;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format => throw _privateConstructorUsedError;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format => throw _privateConstructorUsedError;
 
   /// [elements] - elements you need to pass in
   List<String> get elements => throw _privateConstructorUsedError;
@@ -98,9 +97,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -114,9 +113,9 @@ mixin _$FhirRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -128,9 +127,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -142,9 +141,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -157,9 +156,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -171,9 +170,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -185,9 +184,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -200,9 +199,9 @@ mixin _$FhirRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -213,9 +212,9 @@ mixin _$FhirRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -227,9 +226,9 @@ mixin _$FhirRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -241,9 +240,9 @@ mixin _$FhirRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -257,9 +256,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -275,9 +274,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -292,9 +291,9 @@ mixin _$FhirRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -311,9 +310,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -334,9 +333,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -350,9 +349,9 @@ mixin _$FhirRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -364,9 +363,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -378,9 +377,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -393,9 +392,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -407,9 +406,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -421,9 +420,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -436,9 +435,9 @@ mixin _$FhirRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -449,9 +448,9 @@ mixin _$FhirRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -463,9 +462,9 @@ mixin _$FhirRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -477,9 +476,9 @@ mixin _$FhirRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -493,9 +492,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -511,9 +510,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -528,9 +527,9 @@ mixin _$FhirRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -547,9 +546,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -570,9 +569,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -586,9 +585,9 @@ mixin _$FhirRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -600,9 +599,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -614,9 +613,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -629,9 +628,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -643,9 +642,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -657,9 +656,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -672,9 +671,9 @@ mixin _$FhirRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -685,9 +684,9 @@ mixin _$FhirRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -699,9 +698,9 @@ mixin _$FhirRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -713,9 +712,9 @@ mixin _$FhirRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -729,9 +728,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -747,9 +746,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -764,9 +763,9 @@ mixin _$FhirRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -783,9 +782,9 @@ mixin _$FhirRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -873,9 +872,9 @@ abstract class $FhirRequestCopyWith<$Res> {
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -898,9 +897,9 @@ class _$FhirRequestCopyWithImpl<$Res, $Val extends FhirRequest>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -913,18 +912,18 @@ class _$FhirRequestCopyWithImpl<$Res, $Val extends FhirRequest>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value.elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -965,9 +964,9 @@ abstract class _$$FhirReadRequestImplCopyWith<$Res>
       {Uri base,
       Dstu2ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -988,11 +987,11 @@ class __$$FhirReadRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
+    Object? type = freezed,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -1005,7 +1004,7 @@ class __$$FhirReadRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as Dstu2ResourceType,
@@ -1013,18 +1012,18 @@ class __$$FhirReadRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -1060,9 +1059,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -1093,20 +1092,17 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -1180,7 +1176,7 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirReadRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.fhirId, fhirId) || other.fhirId == fhirId) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
@@ -1200,7 +1196,7 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       fhirId,
       pretty,
       summary,
@@ -1226,9 +1222,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1242,9 +1238,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1256,9 +1252,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1270,9 +1266,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1285,9 +1281,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1299,9 +1295,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1313,9 +1309,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1328,9 +1324,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1341,9 +1337,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1355,9 +1351,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1369,9 +1365,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1385,9 +1381,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1403,9 +1399,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1420,9 +1416,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1439,9 +1435,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -1466,9 +1462,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1482,9 +1478,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1496,9 +1492,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1510,9 +1506,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1525,9 +1521,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1539,9 +1535,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1553,9 +1549,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1568,9 +1564,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1581,9 +1577,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1595,9 +1591,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1609,9 +1605,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1625,9 +1621,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1643,9 +1639,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1660,9 +1656,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1679,9 +1675,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -1706,9 +1702,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1722,9 +1718,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1736,9 +1732,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1750,9 +1746,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1765,9 +1761,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1779,9 +1775,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1793,9 +1789,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1808,9 +1804,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1821,9 +1817,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1835,9 +1831,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1849,9 +1845,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1865,9 +1861,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1883,9 +1879,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1900,9 +1896,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1919,9 +1915,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2026,9 +2022,9 @@ abstract class FhirReadRequest extends FhirRequest {
       {required final Uri base,
       required final Dstu2ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -2054,17 +2050,16 @@ abstract class FhirReadRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -2114,9 +2109,9 @@ abstract class _$$FhirVReadRequestImplCopyWith<$Res>
       Dstu2ResourceType type,
       String fhirId,
       FhirId vid,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -2137,12 +2132,12 @@ class __$$FhirVReadRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
+    Object? type = freezed,
     Object? fhirId = null,
     Object? vid = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -2155,7 +2150,7 @@ class __$$FhirVReadRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as Dstu2ResourceType,
@@ -2167,18 +2162,18 @@ class __$$FhirVReadRequestImplCopyWithImpl<$Res>
           ? _value.vid
           : vid // ignore: cast_nullable_to_non_nullable
               as FhirId,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -2215,9 +2210,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
       required this.type,
       required this.fhirId,
       required this.vid,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -2250,20 +2245,17 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -2337,7 +2329,7 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirVReadRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.fhirId, fhirId) || other.fhirId == fhirId) &&
             (identical(other.vid, vid) || other.vid == vid) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
@@ -2358,7 +2350,7 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       fhirId,
       vid,
       pretty,
@@ -2385,9 +2377,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2401,9 +2393,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2415,9 +2407,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2429,9 +2421,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2444,9 +2436,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2458,9 +2450,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2472,9 +2464,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2487,9 +2479,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2500,9 +2492,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2514,9 +2506,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2528,9 +2520,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2544,9 +2536,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2562,9 +2554,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2579,9 +2571,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2598,9 +2590,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2625,9 +2617,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2641,9 +2633,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2655,9 +2647,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2669,9 +2661,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2684,9 +2676,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2698,9 +2690,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2712,9 +2704,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2727,9 +2719,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2740,9 +2732,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2754,9 +2746,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2768,9 +2760,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2784,9 +2776,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2802,9 +2794,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2819,9 +2811,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2838,9 +2830,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2865,9 +2857,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2881,9 +2873,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2895,9 +2887,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2909,9 +2901,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2924,9 +2916,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2938,9 +2930,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2952,9 +2944,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2967,9 +2959,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2980,9 +2972,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2994,9 +2986,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3008,9 +3000,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3024,9 +3016,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3042,9 +3034,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3059,9 +3051,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3078,9 +3070,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -3186,9 +3178,9 @@ abstract class FhirVReadRequest extends FhirRequest {
       required final Dstu2ResourceType type,
       required final String fhirId,
       required final FhirId vid,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -3215,17 +3207,16 @@ abstract class FhirVReadRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -3273,9 +3264,9 @@ abstract class _$$FhirUpdateRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -3297,9 +3288,9 @@ class __$$FhirUpdateRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -3316,18 +3307,18 @@ class __$$FhirUpdateRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -3362,9 +3353,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
   const _$FhirUpdateRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -3389,20 +3380,17 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -3521,9 +3509,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3537,9 +3525,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3551,9 +3539,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3565,9 +3553,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3580,9 +3568,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3594,9 +3582,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3608,9 +3596,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -3623,9 +3611,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3636,9 +3624,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -3650,9 +3638,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3664,9 +3652,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3680,9 +3668,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3698,9 +3686,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3715,9 +3703,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3734,9 +3722,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -3761,9 +3749,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3777,9 +3765,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3791,9 +3779,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3805,9 +3793,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3820,9 +3808,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3834,9 +3822,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3848,9 +3836,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -3863,9 +3851,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3876,9 +3864,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -3890,9 +3878,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3904,9 +3892,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3920,9 +3908,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3938,9 +3926,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3955,9 +3943,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3974,9 +3962,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4001,9 +3989,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4017,9 +4005,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4031,9 +4019,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4045,9 +4033,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4060,9 +4048,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4074,9 +4062,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4088,9 +4076,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4103,9 +4091,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4116,9 +4104,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -4130,9 +4118,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4144,9 +4132,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4160,9 +4148,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4178,9 +4166,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4195,9 +4183,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4214,9 +4202,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4320,9 +4308,9 @@ abstract class FhirUpdateRequest extends FhirRequest {
   const factory FhirUpdateRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -4343,17 +4331,16 @@ abstract class FhirUpdateRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -4401,9 +4388,9 @@ abstract class _$$FhirPatchRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -4425,9 +4412,9 @@ class __$$FhirPatchRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -4444,18 +4431,18 @@ class __$$FhirPatchRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -4490,9 +4477,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
   const _$FhirPatchRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -4517,20 +4504,17 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -4649,9 +4633,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4665,9 +4649,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4679,9 +4663,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4693,9 +4677,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4708,9 +4692,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4722,9 +4706,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4736,9 +4720,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4751,9 +4735,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4764,9 +4748,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -4778,9 +4762,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4792,9 +4776,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4808,9 +4792,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4826,9 +4810,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4843,9 +4827,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4862,9 +4846,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4889,9 +4873,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4905,9 +4889,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4919,9 +4903,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4933,9 +4917,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4948,9 +4932,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4962,9 +4946,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4976,9 +4960,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4991,9 +4975,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5004,9 +4988,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5018,9 +5002,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5032,9 +5016,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5048,9 +5032,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5066,9 +5050,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5083,9 +5067,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5102,9 +5086,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -5129,9 +5113,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5145,9 +5129,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5159,9 +5143,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5173,9 +5157,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5188,9 +5172,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5202,9 +5186,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5216,9 +5200,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -5231,9 +5215,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5244,9 +5228,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5258,9 +5242,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5272,9 +5256,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5288,9 +5272,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5306,9 +5290,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5323,9 +5307,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5342,9 +5326,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -5448,9 +5432,9 @@ abstract class FhirPatchRequest extends FhirRequest {
   const factory FhirPatchRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -5471,17 +5455,16 @@ abstract class FhirPatchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -5530,9 +5513,9 @@ abstract class _$$FhirDeleteRequestImplCopyWith<$Res>
       {Uri base,
       Dstu2ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -5553,11 +5536,11 @@ class __$$FhirDeleteRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
+    Object? type = freezed,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -5570,7 +5553,7 @@ class __$$FhirDeleteRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as Dstu2ResourceType,
@@ -5578,18 +5561,18 @@ class __$$FhirDeleteRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -5625,9 +5608,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -5658,20 +5641,17 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -5745,7 +5725,7 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirDeleteRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.fhirId, fhirId) || other.fhirId == fhirId) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
@@ -5765,7 +5745,7 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       fhirId,
       pretty,
       summary,
@@ -5791,9 +5771,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5807,9 +5787,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5821,9 +5801,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5835,9 +5815,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5850,9 +5830,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5864,9 +5844,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5878,9 +5858,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -5893,9 +5873,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5906,9 +5886,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5920,9 +5900,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5934,9 +5914,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5950,9 +5930,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5968,9 +5948,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5985,9 +5965,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6004,9 +5984,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6031,9 +6011,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6047,9 +6027,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6061,9 +6041,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6075,9 +6055,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6090,9 +6070,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6104,9 +6084,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6118,9 +6098,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -6133,9 +6113,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6146,9 +6126,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -6160,9 +6140,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6174,9 +6154,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6190,9 +6170,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6208,9 +6188,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6225,9 +6205,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6244,9 +6224,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6271,9 +6251,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6287,9 +6267,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6301,9 +6281,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6315,9 +6295,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6330,9 +6310,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6344,9 +6324,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6358,9 +6338,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -6373,9 +6353,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6386,9 +6366,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -6400,9 +6380,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6414,9 +6394,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6430,9 +6410,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6448,9 +6428,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6465,9 +6445,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6484,9 +6464,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6591,9 +6571,9 @@ abstract class FhirDeleteRequest extends FhirRequest {
       {required final Uri base,
       required final Dstu2ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -6619,17 +6599,16 @@ abstract class FhirDeleteRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -6677,9 +6656,9 @@ abstract class _$$FhirCreateRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -6701,9 +6680,9 @@ class __$$FhirCreateRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -6720,18 +6699,18 @@ class __$$FhirCreateRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -6766,9 +6745,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
   const _$FhirCreateRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -6793,20 +6772,17 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -6925,9 +6901,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6941,9 +6917,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6955,9 +6931,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6969,9 +6945,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6984,9 +6960,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6998,9 +6974,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7012,9 +6988,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7027,9 +7003,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7040,9 +7016,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7054,9 +7030,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7068,9 +7044,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7084,9 +7060,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7102,9 +7078,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7119,9 +7095,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7138,9 +7114,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7165,9 +7141,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7181,9 +7157,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7195,9 +7171,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7209,9 +7185,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7224,9 +7200,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7238,9 +7214,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7252,9 +7228,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7267,9 +7243,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7280,9 +7256,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7294,9 +7270,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7308,9 +7284,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7324,9 +7300,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7342,9 +7318,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7359,9 +7335,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7378,9 +7354,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7405,9 +7381,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7421,9 +7397,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7435,9 +7411,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7449,9 +7425,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7464,9 +7440,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7478,9 +7454,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7492,9 +7468,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7507,9 +7483,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7520,9 +7496,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7534,9 +7510,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7548,9 +7524,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7564,9 +7540,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7582,9 +7558,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7599,9 +7575,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7618,9 +7594,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7724,9 +7700,9 @@ abstract class FhirCreateRequest extends FhirRequest {
   const factory FhirCreateRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -7747,17 +7723,16 @@ abstract class FhirCreateRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -7805,9 +7780,9 @@ abstract class _$$FhirSearchRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Dstu2ResourceType type,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       bool usePost,
@@ -7830,10 +7805,10 @@ class __$$FhirSearchRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
-    Object? pretty = null,
+    Object? type = freezed,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? usePost = null,
@@ -7848,22 +7823,22 @@ class __$$FhirSearchRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as Dstu2ResourceType,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -7906,9 +7881,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
   const _$FhirSearchRequestImpl(
       {required this.base,
       required this.type,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.usePost = false,
@@ -7937,20 +7912,17 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -8033,7 +8005,7 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirSearchRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
             (identical(other.format, format) || other.format == format) &&
@@ -8055,7 +8027,7 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       pretty,
       summary,
       format,
@@ -8082,9 +8054,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8098,9 +8070,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8112,9 +8084,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8126,9 +8098,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8141,9 +8113,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8155,9 +8127,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8169,9 +8141,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8184,9 +8156,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8197,9 +8169,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8211,9 +8183,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8225,9 +8197,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8241,9 +8213,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8259,9 +8231,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8276,9 +8248,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8295,9 +8267,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8322,9 +8294,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8338,9 +8310,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8352,9 +8324,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8366,9 +8338,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8381,9 +8353,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8395,9 +8367,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8409,9 +8381,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8424,9 +8396,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8437,9 +8409,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8451,9 +8423,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8465,9 +8437,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8481,9 +8453,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8499,9 +8471,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8516,9 +8488,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8535,9 +8507,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8562,9 +8534,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8578,9 +8550,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8592,9 +8564,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8606,9 +8578,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8621,9 +8593,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8635,9 +8607,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8649,9 +8621,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8664,9 +8636,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8677,9 +8649,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8691,9 +8663,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8705,9 +8677,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8721,9 +8693,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8739,9 +8711,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8756,9 +8728,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8775,9 +8747,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8881,9 +8853,9 @@ abstract class FhirSearchRequest extends FhirRequest {
   const factory FhirSearchRequest(
       {required final Uri base,
       required final Dstu2ResourceType type,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final bool usePost,
@@ -8908,17 +8880,16 @@ abstract class FhirSearchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -8970,9 +8941,9 @@ abstract class _$$FhirSearchAllRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -8993,9 +8964,9 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -9008,18 +8979,18 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -9053,9 +9024,9 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
 class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
   const _$FhirSearchAllRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -9078,20 +9049,17 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -9208,9 +9176,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9224,9 +9192,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9238,9 +9206,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9252,9 +9220,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9267,9 +9235,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9281,9 +9249,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9295,9 +9263,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9310,9 +9278,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9323,9 +9291,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9337,9 +9305,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9351,9 +9319,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9367,9 +9335,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9385,9 +9353,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9402,9 +9370,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9421,9 +9389,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -9448,9 +9416,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9464,9 +9432,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9478,9 +9446,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9492,9 +9460,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9507,9 +9475,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9521,9 +9489,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9535,9 +9503,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9550,9 +9518,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9563,9 +9531,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9577,9 +9545,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9591,9 +9559,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9607,9 +9575,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9625,9 +9593,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9642,9 +9610,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9661,9 +9629,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -9688,9 +9656,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9704,9 +9672,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9718,9 +9686,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9732,9 +9700,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9747,9 +9715,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9761,9 +9729,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9775,9 +9743,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9790,9 +9758,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9803,9 +9771,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9817,9 +9785,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9831,9 +9799,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9847,9 +9815,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9865,9 +9833,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9882,9 +9850,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9901,9 +9869,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10006,9 +9974,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
 abstract class FhirSearchAllRequest extends FhirRequest {
   const factory FhirSearchAllRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -10028,17 +9996,16 @@ abstract class FhirSearchAllRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -10086,9 +10053,9 @@ abstract class _$$FhirCapabilitiesRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Mode mode,
@@ -10111,9 +10078,9 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mode = null,
@@ -10127,18 +10094,18 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -10176,9 +10143,9 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
 class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
   const _$FhirCapabilitiesRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mode = Mode.full,
@@ -10202,20 +10169,17 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -10338,9 +10302,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10354,9 +10318,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10368,9 +10332,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10382,9 +10346,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10397,9 +10361,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10411,9 +10375,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10425,9 +10389,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10440,9 +10404,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10453,9 +10417,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10467,9 +10431,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10481,9 +10445,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10497,9 +10461,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10515,9 +10479,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10532,9 +10496,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10551,9 +10515,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10578,9 +10542,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10594,9 +10558,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10608,9 +10572,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10622,9 +10586,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10637,9 +10601,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10651,9 +10615,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10665,9 +10629,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10680,9 +10644,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10693,9 +10657,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10707,9 +10671,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10721,9 +10685,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10737,9 +10701,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10755,9 +10719,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10772,9 +10736,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10791,9 +10755,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10818,9 +10782,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10834,9 +10798,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10848,9 +10812,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10862,9 +10826,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10877,9 +10841,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10891,9 +10855,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10905,9 +10869,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10920,9 +10884,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10933,9 +10897,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10947,9 +10911,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10961,9 +10925,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10977,9 +10941,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10995,9 +10959,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11012,9 +10976,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11031,9 +10995,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11136,9 +11100,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
 abstract class FhirCapabilitiesRequest extends FhirRequest {
   const factory FhirCapabilitiesRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final Mode mode,
@@ -11159,17 +11123,16 @@ abstract class FhirCapabilitiesRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -11220,9 +11183,9 @@ abstract class _$$FhirTransactionRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Bundle bundle,
@@ -11230,8 +11193,6 @@ abstract class _$$FhirTransactionRequestImplCopyWith<$Res>
       String accept,
       @JsonKey(includeFromJson: false, includeToJson: false) Client? client,
       Map<String, String>? headers});
-
-  $BundleCopyWith<$Res> get bundle;
 }
 
 /// @nodoc
@@ -11247,12 +11208,12 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
-    Object? bundle = null,
+    Object? bundle = freezed,
     Object? mimeType = freezed,
     Object? accept = null,
     Object? client = freezed,
@@ -11263,18 +11224,18 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -11283,7 +11244,7 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
           ? _value._parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      bundle: null == bundle
+      bundle: freezed == bundle
           ? _value.bundle
           : bundle // ignore: cast_nullable_to_non_nullable
               as Bundle,
@@ -11305,14 +11266,6 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
               as Map<String, String>?,
     ));
   }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $BundleCopyWith<$Res> get bundle {
-    return $BundleCopyWith<$Res>(_value.bundle, (value) {
-      return _then(_value.copyWith(bundle: value));
-    });
-  }
 }
 
 /// @nodoc
@@ -11320,9 +11273,9 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
 class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
   const _$FhirTransactionRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       required this.bundle,
@@ -11346,20 +11299,17 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -11443,7 +11393,7 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             const DeepCollectionEquality().equals(other._elements, _elements) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
-            (identical(other.bundle, bundle) || other.bundle == bundle) &&
+            const DeepCollectionEquality().equals(other.bundle, bundle) &&
             (identical(other.mimeType, mimeType) ||
                 other.mimeType == mimeType) &&
             (identical(other.accept, accept) || other.accept == accept) &&
@@ -11461,7 +11411,7 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
       format,
       const DeepCollectionEquality().hash(_elements),
       const DeepCollectionEquality().hash(_parameters),
-      bundle,
+      const DeepCollectionEquality().hash(bundle),
       mimeType,
       accept,
       client,
@@ -11481,9 +11431,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11497,9 +11447,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11511,9 +11461,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11525,9 +11475,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11540,9 +11490,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11554,9 +11504,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11568,9 +11518,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -11583,9 +11533,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11596,9 +11546,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -11610,9 +11560,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11624,9 +11574,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11640,9 +11590,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11658,9 +11608,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11675,9 +11625,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11694,9 +11644,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11721,9 +11671,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11737,9 +11687,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11751,9 +11701,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11765,9 +11715,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11780,9 +11730,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11794,9 +11744,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11808,9 +11758,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -11823,9 +11773,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11836,9 +11786,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -11850,9 +11800,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11864,9 +11814,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11880,9 +11830,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11898,9 +11848,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11915,9 +11865,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11934,9 +11884,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11961,9 +11911,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11977,9 +11927,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11991,9 +11941,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12005,9 +11955,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12020,9 +11970,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12034,9 +11984,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12048,9 +11998,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12063,9 +12013,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12076,9 +12026,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12090,9 +12040,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12104,9 +12054,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12120,9 +12070,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12138,9 +12088,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12155,9 +12105,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12174,9 +12124,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -12279,9 +12229,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
 abstract class FhirTransactionRequest extends FhirRequest {
   const factory FhirTransactionRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       required final Bundle bundle,
@@ -12302,17 +12252,16 @@ abstract class FhirTransactionRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -12362,9 +12311,9 @@ abstract class _$$FhirBatchRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Bundle bundle,
@@ -12372,8 +12321,6 @@ abstract class _$$FhirBatchRequestImplCopyWith<$Res>
       String accept,
       @JsonKey(includeFromJson: false, includeToJson: false) Client? client,
       Map<String, String>? headers});
-
-  $BundleCopyWith<$Res> get bundle;
 }
 
 /// @nodoc
@@ -12388,12 +12335,12 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
-    Object? bundle = null,
+    Object? bundle = freezed,
     Object? mimeType = freezed,
     Object? accept = null,
     Object? client = freezed,
@@ -12404,18 +12351,18 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -12424,7 +12371,7 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
           ? _value._parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      bundle: null == bundle
+      bundle: freezed == bundle
           ? _value.bundle
           : bundle // ignore: cast_nullable_to_non_nullable
               as Bundle,
@@ -12446,14 +12393,6 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
               as Map<String, String>?,
     ));
   }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $BundleCopyWith<$Res> get bundle {
-    return $BundleCopyWith<$Res>(_value.bundle, (value) {
-      return _then(_value.copyWith(bundle: value));
-    });
-  }
 }
 
 /// @nodoc
@@ -12461,9 +12400,9 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
 class _$FhirBatchRequestImpl extends FhirBatchRequest {
   const _$FhirBatchRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       required this.bundle,
@@ -12487,20 +12426,17 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -12584,7 +12520,7 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             const DeepCollectionEquality().equals(other._elements, _elements) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
-            (identical(other.bundle, bundle) || other.bundle == bundle) &&
+            const DeepCollectionEquality().equals(other.bundle, bundle) &&
             (identical(other.mimeType, mimeType) ||
                 other.mimeType == mimeType) &&
             (identical(other.accept, accept) || other.accept == accept) &&
@@ -12602,7 +12538,7 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
       format,
       const DeepCollectionEquality().hash(_elements),
       const DeepCollectionEquality().hash(_parameters),
-      bundle,
+      const DeepCollectionEquality().hash(bundle),
       mimeType,
       accept,
       client,
@@ -12622,9 +12558,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12638,9 +12574,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12652,9 +12588,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12666,9 +12602,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12681,9 +12617,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12695,9 +12631,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12709,9 +12645,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12724,9 +12660,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12737,9 +12673,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12751,9 +12687,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12765,9 +12701,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12781,9 +12717,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12799,9 +12735,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12816,9 +12752,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12835,9 +12771,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -12862,9 +12798,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12878,9 +12814,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12892,9 +12828,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12906,9 +12842,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12921,9 +12857,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12935,9 +12871,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12949,9 +12885,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12964,9 +12900,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12977,9 +12913,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12991,9 +12927,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13005,9 +12941,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13021,9 +12957,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13039,9 +12975,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13056,9 +12992,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13075,9 +13011,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -13102,9 +13038,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13118,9 +13054,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13132,9 +13068,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13146,9 +13082,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13161,9 +13097,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13175,9 +13111,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13189,9 +13125,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -13204,9 +13140,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13217,9 +13153,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -13231,9 +13167,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13245,9 +13181,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13261,9 +13197,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13279,9 +13215,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13296,9 +13232,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13315,9 +13251,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -13420,9 +13356,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
 abstract class FhirBatchRequest extends FhirRequest {
   const factory FhirBatchRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       required final Bundle bundle,
@@ -13443,17 +13379,16 @@ abstract class FhirBatchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -13505,9 +13440,9 @@ abstract class _$$FhirHistoryRequestImplCopyWith<$Res>
       {Uri base,
       Dstu2ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -13532,11 +13467,11 @@ class __$$FhirHistoryRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
+    Object? type = freezed,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -13553,7 +13488,7 @@ class __$$FhirHistoryRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as Dstu2ResourceType,
@@ -13561,18 +13496,18 @@ class __$$FhirHistoryRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -13624,9 +13559,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -13661,20 +13596,17 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -13769,7 +13701,7 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirHistoryRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.fhirId, fhirId) || other.fhirId == fhirId) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
@@ -13794,7 +13726,7 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       fhirId,
       pretty,
       summary,
@@ -13824,9 +13756,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13840,9 +13772,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13854,9 +13786,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13868,9 +13800,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13883,9 +13815,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13897,9 +13829,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13911,9 +13843,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -13926,9 +13858,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13939,9 +13871,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -13953,9 +13885,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13967,9 +13899,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13983,9 +13915,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14001,9 +13933,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14018,9 +13950,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14037,9 +13969,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14079,9 +14011,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14095,9 +14027,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14109,9 +14041,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14123,9 +14055,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14138,9 +14070,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14152,9 +14084,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14166,9 +14098,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -14181,9 +14113,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14194,9 +14126,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -14208,9 +14140,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14222,9 +14154,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14238,9 +14170,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14256,9 +14188,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14273,9 +14205,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14292,9 +14224,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14334,9 +14266,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14350,9 +14282,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14364,9 +14296,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14378,9 +14310,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14393,9 +14325,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14407,9 +14339,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14421,9 +14353,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -14436,9 +14368,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14449,9 +14381,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -14463,9 +14395,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14477,9 +14409,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14493,9 +14425,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14511,9 +14443,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14528,9 +14460,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14547,9 +14479,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14669,9 +14601,9 @@ abstract class FhirHistoryRequest extends FhirRequest {
       {required final Uri base,
       required final Dstu2ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -14701,17 +14633,16 @@ abstract class FhirHistoryRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -14777,9 +14708,9 @@ abstract class _$$FhirHistoryTypeRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Dstu2ResourceType type,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -14805,10 +14736,10 @@ class __$$FhirHistoryTypeRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
-    Object? pretty = null,
+    Object? type = freezed,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -14825,22 +14756,22 @@ class __$$FhirHistoryTypeRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as Dstu2ResourceType,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -14891,9 +14822,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
   const _$FhirHistoryTypeRequestImpl(
       {required this.base,
       required this.type,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -14924,20 +14855,17 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -15032,7 +14960,7 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirHistoryTypeRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
             (identical(other.format, format) || other.format == format) &&
@@ -15056,7 +14984,7 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       pretty,
       summary,
       format,
@@ -15085,9 +15013,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15101,9 +15029,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15115,9 +15043,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15129,9 +15057,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15144,9 +15072,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15158,9 +15086,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15172,9 +15100,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15187,9 +15115,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15200,9 +15128,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15214,9 +15142,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15228,9 +15156,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15244,9 +15172,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15262,9 +15190,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15279,9 +15207,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15298,9 +15226,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15339,9 +15267,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15355,9 +15283,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15369,9 +15297,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15383,9 +15311,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15398,9 +15326,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15412,9 +15340,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15426,9 +15354,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15441,9 +15369,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15454,9 +15382,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15468,9 +15396,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15482,9 +15410,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15498,9 +15426,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15516,9 +15444,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15533,9 +15461,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15552,9 +15480,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15593,9 +15521,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15609,9 +15537,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15623,9 +15551,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15637,9 +15565,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15652,9 +15580,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15666,9 +15594,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15680,9 +15608,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15695,9 +15623,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15708,9 +15636,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15722,9 +15650,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15736,9 +15664,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15752,9 +15680,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15770,9 +15698,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15787,9 +15715,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15806,9 +15734,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15926,9 +15854,9 @@ abstract class FhirHistoryTypeRequest extends FhirRequest {
   const factory FhirHistoryTypeRequest(
       {required final Uri base,
       required final Dstu2ResourceType type,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -15955,17 +15883,16 @@ abstract class FhirHistoryTypeRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -16030,9 +15957,9 @@ abstract class _$$FhirHistoryAllRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -16057,9 +15984,9 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -16076,18 +16003,18 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -16137,9 +16064,9 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
 class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
   const _$FhirHistoryAllRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -16166,20 +16093,17 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -16325,9 +16249,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16341,9 +16265,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16355,9 +16279,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16369,9 +16293,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16384,9 +16308,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16398,9 +16322,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16412,9 +16336,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16427,9 +16351,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16440,9 +16364,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16454,9 +16378,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16468,9 +16392,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16484,9 +16408,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16502,9 +16426,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16519,9 +16443,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16538,9 +16462,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -16565,9 +16489,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16581,9 +16505,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16595,9 +16519,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16609,9 +16533,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16624,9 +16548,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16638,9 +16562,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16652,9 +16576,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16667,9 +16591,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16680,9 +16604,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16694,9 +16618,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16708,9 +16632,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16724,9 +16648,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16742,9 +16666,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16759,9 +16683,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16778,9 +16702,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -16805,9 +16729,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16821,9 +16745,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16835,9 +16759,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16849,9 +16773,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16864,9 +16788,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16878,9 +16802,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16892,9 +16816,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16907,9 +16831,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16920,9 +16844,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16934,9 +16858,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16948,9 +16872,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16964,9 +16888,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16982,9 +16906,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16999,9 +16923,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17018,9 +16942,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -17123,9 +17047,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
 abstract class FhirHistoryAllRequest extends FhirRequest {
   const factory FhirHistoryAllRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -17149,17 +17073,16 @@ abstract class FhirHistoryAllRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -17225,9 +17148,9 @@ abstract class _$$FhirOperationRequestImplCopyWith<$Res>
       {Uri base,
       Dstu2ResourceType? type,
       String? fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Parameters? fhirParameter,
@@ -17238,8 +17161,6 @@ abstract class _$$FhirOperationRequestImplCopyWith<$Res>
       String accept,
       @JsonKey(includeFromJson: false, includeToJson: false) Client? client,
       Map<String, String>? headers});
-
-  $ParametersCopyWith<$Res>? get fhirParameter;
 }
 
 /// @nodoc
@@ -17256,9 +17177,9 @@ class __$$FhirOperationRequestImplCopyWithImpl<$Res>
     Object? base = null,
     Object? type = freezed,
     Object? fhirId = freezed,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? fhirParameter = freezed,
@@ -17283,18 +17204,18 @@ class __$$FhirOperationRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String?,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -17337,18 +17258,6 @@ class __$$FhirOperationRequestImplCopyWithImpl<$Res>
               as Map<String, String>?,
     ));
   }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $ParametersCopyWith<$Res>? get fhirParameter {
-    if (_value.fhirParameter == null) {
-      return null;
-    }
-
-    return $ParametersCopyWith<$Res>(_value.fhirParameter!, (value) {
-      return _then(_value.copyWith(fhirParameter: value));
-    });
-  }
 }
 
 /// @nodoc
@@ -17358,9 +17267,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
       {required this.base,
       this.type,
       this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.fhirParameter,
@@ -17391,20 +17300,17 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -17493,7 +17399,7 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirOperationRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.fhirId, fhirId) || other.fhirId == fhirId) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
@@ -17501,8 +17407,8 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             const DeepCollectionEquality().equals(other._elements, _elements) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
-            (identical(other.fhirParameter, fhirParameter) ||
-                other.fhirParameter == fhirParameter) &&
+            const DeepCollectionEquality()
+                .equals(other.fhirParameter, fhirParameter) &&
             (identical(other.operation, operation) ||
                 other.operation == operation) &&
             (identical(other.usePost, usePost) || other.usePost == usePost) &&
@@ -17520,14 +17426,14 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       fhirId,
       pretty,
       summary,
       format,
       const DeepCollectionEquality().hash(_elements),
       const DeepCollectionEquality().hash(_parameters),
-      fhirParameter,
+      const DeepCollectionEquality().hash(fhirParameter),
       operation,
       usePost,
       useFormData,
@@ -17551,9 +17457,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17567,9 +17473,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17581,9 +17487,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17595,9 +17501,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17610,9 +17516,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17624,9 +17530,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17638,9 +17544,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -17653,9 +17559,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17666,9 +17572,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -17680,9 +17586,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17694,9 +17600,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17710,9 +17616,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17728,9 +17634,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17745,9 +17651,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17764,9 +17670,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -17806,9 +17712,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17822,9 +17728,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17836,9 +17742,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17850,9 +17756,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17865,9 +17771,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17879,9 +17785,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17893,9 +17799,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -17908,9 +17814,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17921,9 +17827,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -17935,9 +17841,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17949,9 +17855,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17965,9 +17871,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17983,9 +17889,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18000,9 +17906,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18019,9 +17925,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -18061,9 +17967,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18077,9 +17983,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Dstu2ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18091,9 +17997,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18105,9 +18011,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18120,9 +18026,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18134,9 +18040,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18148,9 +18054,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -18163,9 +18069,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18176,9 +18082,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -18190,9 +18096,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -18204,9 +18110,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -18220,9 +18126,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18238,9 +18144,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Dstu2ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18255,9 +18161,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18274,9 +18180,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Dstu2ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -18396,9 +18302,9 @@ abstract class FhirOperationRequest extends FhirRequest {
       {required final Uri base,
       final Dstu2ResourceType? type,
       final String? fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final Parameters? fhirParameter,
@@ -18424,17 +18330,16 @@ abstract class FhirOperationRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in

--- a/lib/dstu2/fhir_request.g.dart
+++ b/lib/dstu2/fhir_request.g.dart
@@ -12,10 +12,10 @@ _$FhirReadRequestImpl _$$FhirReadRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$Dstu2ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -179,10 +179,10 @@ _$FhirVReadRequestImpl _$$FhirVReadRequestImplFromJson(
       type: $enumDecode(_$Dstu2ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
       vid: FhirId.fromJson(json['vid']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -231,10 +231,10 @@ _$FhirUpdateRequestImpl _$$FhirUpdateRequestImplFromJson(
     _$FhirUpdateRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -281,10 +281,10 @@ _$FhirPatchRequestImpl _$$FhirPatchRequestImplFromJson(
     _$FhirPatchRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -332,10 +332,10 @@ _$FhirDeleteRequestImpl _$$FhirDeleteRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$Dstu2ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -383,10 +383,10 @@ _$FhirCreateRequestImpl _$$FhirCreateRequestImplFromJson(
     _$FhirCreateRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -433,10 +433,10 @@ _$FhirSearchRequestImpl _$$FhirSearchRequestImplFromJson(
     _$FhirSearchRequestImpl(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$Dstu2ResourceTypeEnumMap, json['type']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -496,10 +496,10 @@ _$FhirSearchAllRequestImpl _$$FhirSearchAllRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirSearchAllRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -544,10 +544,10 @@ _$FhirCapabilitiesRequestImpl _$$FhirCapabilitiesRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirCapabilitiesRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -600,10 +600,10 @@ _$FhirTransactionRequestImpl _$$FhirTransactionRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirTransactionRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -650,10 +650,10 @@ _$FhirBatchRequestImpl _$$FhirBatchRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirBatchRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -702,10 +702,10 @@ _$FhirHistoryRequestImpl _$$FhirHistoryRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$Dstu2ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -765,10 +765,10 @@ _$FhirHistoryTypeRequestImpl _$$FhirHistoryTypeRequestImplFromJson(
     _$FhirHistoryTypeRequestImpl(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$Dstu2ResourceTypeEnumMap, json['type']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -826,10 +826,10 @@ _$FhirHistoryAllRequestImpl _$$FhirHistoryAllRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirHistoryAllRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -888,10 +888,10 @@ _$FhirOperationRequestImpl _$$FhirOperationRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecodeNullable(_$Dstu2ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String?,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??

--- a/lib/r4/fhir_request.dart
+++ b/lib/r4/fhir_request.dart
@@ -46,15 +46,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -107,15 +106,14 @@ class FhirRequest with _$FhirRequest {
     required FhirId vid,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -159,15 +157,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -211,15 +208,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -270,15 +266,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -322,15 +317,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -379,15 +373,14 @@ class FhirRequest with _$FhirRequest {
     required R4ResourceType type,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -435,15 +428,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -487,15 +479,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -542,15 +533,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -597,15 +587,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -668,15 +657,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -749,15 +737,14 @@ class FhirRequest with _$FhirRequest {
     required R4ResourceType type,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -826,15 +813,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -900,15 +886,14 @@ class FhirRequest with _$FhirRequest {
     String? fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -1586,13 +1571,13 @@ class FhirRequest with _$FhirRequest {
       orElse: () => '');
 
   /// specifies the format
-  String _format({bool join = false}) => maybeMap(
+  String _format({bool join = false}) => format == null ? '' : maybeMap(
       capabilities: (FhirCapabilitiesRequest request) =>
           _encodeParam('_format=${request.format}'),
       orElse: () => _encodeParam('_format=$format', join: join));
 
   /// assigns if you want it pretty
-  String _pretty({bool join = true}) =>
+  String _pretty({bool join = true}) => pretty == null ? '' :
       _encodeParam('_pretty=$pretty', join: join);
 
   /// assigns if you want the summary

--- a/lib/r4/fhir_request.dart
+++ b/lib/r4/fhir_request.dart
@@ -51,7 +51,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -111,7 +111,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -162,7 +162,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -213,7 +213,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -271,7 +271,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -322,7 +322,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -378,7 +378,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -433,7 +433,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -484,7 +484,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -538,7 +538,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -592,7 +592,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -662,7 +662,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -742,7 +742,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -818,7 +818,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -891,7 +891,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -1571,14 +1571,16 @@ class FhirRequest with _$FhirRequest {
       orElse: () => '');
 
   /// specifies the format
-  String _format({bool join = false}) => format == null ? '' : maybeMap(
-      capabilities: (FhirCapabilitiesRequest request) =>
-          _encodeParam('_format=${request.format}'),
-      orElse: () => _encodeParam('_format=$format', join: join));
+  String _format({bool join = false}) => format == null
+      ? ''
+      : maybeMap(
+          capabilities: (FhirCapabilitiesRequest request) =>
+              _encodeParam('_format=${request.format}'),
+          orElse: () => _encodeParam('_format=$format', join: join));
 
   /// assigns if you want it pretty
-  String _pretty({bool join = true}) => pretty == null ? '' :
-      _encodeParam('_pretty=$pretty', join: join);
+  String _pretty({bool join = true}) =>
+      pretty == null ? '' : _encodeParam('_pretty=$pretty', join: join);
 
   /// assigns if you want the summary
   String _summary({bool join = true}) => summary != Summary.none

--- a/lib/r4/fhir_request.freezed.dart
+++ b/lib/r4/fhir_request.freezed.dart
@@ -59,15 +59,14 @@ mixin _$FhirRequest {
   Uri get base => throw _privateConstructorUsedError;
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty => throw _privateConstructorUsedError;
+  bool? get pretty => throw _privateConstructorUsedError;
 
   /// [summary] - do you want the result to be a summary
   Summary get summary => throw _privateConstructorUsedError;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format => throw _privateConstructorUsedError;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format => throw _privateConstructorUsedError;
 
   /// [elements] - elements you need to pass in
   List<String> get elements => throw _privateConstructorUsedError;
@@ -98,9 +97,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -114,9 +113,9 @@ mixin _$FhirRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -128,9 +127,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -142,9 +141,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -157,9 +156,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -171,9 +170,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -185,9 +184,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -200,9 +199,9 @@ mixin _$FhirRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -213,9 +212,9 @@ mixin _$FhirRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -227,9 +226,9 @@ mixin _$FhirRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -241,9 +240,9 @@ mixin _$FhirRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -257,9 +256,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -275,9 +274,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -292,9 +291,9 @@ mixin _$FhirRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -311,9 +310,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -334,9 +333,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -350,9 +349,9 @@ mixin _$FhirRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -364,9 +363,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -378,9 +377,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -393,9 +392,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -407,9 +406,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -421,9 +420,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -436,9 +435,9 @@ mixin _$FhirRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -449,9 +448,9 @@ mixin _$FhirRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -463,9 +462,9 @@ mixin _$FhirRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -477,9 +476,9 @@ mixin _$FhirRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -493,9 +492,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -511,9 +510,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -528,9 +527,9 @@ mixin _$FhirRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -547,9 +546,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -570,9 +569,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -586,9 +585,9 @@ mixin _$FhirRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -600,9 +599,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -614,9 +613,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -629,9 +628,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -643,9 +642,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -657,9 +656,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -672,9 +671,9 @@ mixin _$FhirRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -685,9 +684,9 @@ mixin _$FhirRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -699,9 +698,9 @@ mixin _$FhirRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -713,9 +712,9 @@ mixin _$FhirRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -729,9 +728,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -747,9 +746,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -764,9 +763,9 @@ mixin _$FhirRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -783,9 +782,9 @@ mixin _$FhirRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -873,9 +872,9 @@ abstract class $FhirRequestCopyWith<$Res> {
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -898,9 +897,9 @@ class _$FhirRequestCopyWithImpl<$Res, $Val extends FhirRequest>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -913,18 +912,18 @@ class _$FhirRequestCopyWithImpl<$Res, $Val extends FhirRequest>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value.elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -965,9 +964,9 @@ abstract class _$$FhirReadRequestImplCopyWith<$Res>
       {Uri base,
       R4ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -988,11 +987,11 @@ class __$$FhirReadRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
+    Object? type = freezed,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -1005,7 +1004,7 @@ class __$$FhirReadRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as R4ResourceType,
@@ -1013,18 +1012,18 @@ class __$$FhirReadRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -1060,9 +1059,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -1093,20 +1092,17 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -1180,7 +1176,7 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirReadRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.fhirId, fhirId) || other.fhirId == fhirId) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
@@ -1200,7 +1196,7 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       fhirId,
       pretty,
       summary,
@@ -1226,9 +1222,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1242,9 +1238,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1256,9 +1252,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1270,9 +1266,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1285,9 +1281,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1299,9 +1295,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1313,9 +1309,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1328,9 +1324,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1341,9 +1337,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1355,9 +1351,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1369,9 +1365,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1385,9 +1381,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1403,9 +1399,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1420,9 +1416,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1439,9 +1435,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -1466,9 +1462,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1482,9 +1478,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1496,9 +1492,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1510,9 +1506,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1525,9 +1521,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1539,9 +1535,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1553,9 +1549,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1568,9 +1564,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1581,9 +1577,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1595,9 +1591,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1609,9 +1605,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1625,9 +1621,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1643,9 +1639,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1660,9 +1656,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1679,9 +1675,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -1706,9 +1702,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1722,9 +1718,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1736,9 +1732,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1750,9 +1746,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1765,9 +1761,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1779,9 +1775,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1793,9 +1789,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1808,9 +1804,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1821,9 +1817,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1835,9 +1831,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1849,9 +1845,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1865,9 +1861,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1883,9 +1879,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1900,9 +1896,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1919,9 +1915,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2026,9 +2022,9 @@ abstract class FhirReadRequest extends FhirRequest {
       {required final Uri base,
       required final R4ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -2054,17 +2050,16 @@ abstract class FhirReadRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -2114,9 +2109,9 @@ abstract class _$$FhirVReadRequestImplCopyWith<$Res>
       R4ResourceType type,
       String fhirId,
       FhirId vid,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -2137,12 +2132,12 @@ class __$$FhirVReadRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
+    Object? type = freezed,
     Object? fhirId = null,
     Object? vid = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -2155,7 +2150,7 @@ class __$$FhirVReadRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as R4ResourceType,
@@ -2167,18 +2162,18 @@ class __$$FhirVReadRequestImplCopyWithImpl<$Res>
           ? _value.vid
           : vid // ignore: cast_nullable_to_non_nullable
               as FhirId,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -2215,9 +2210,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
       required this.type,
       required this.fhirId,
       required this.vid,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -2250,20 +2245,17 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -2337,7 +2329,7 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirVReadRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.fhirId, fhirId) || other.fhirId == fhirId) &&
             (identical(other.vid, vid) || other.vid == vid) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
@@ -2358,7 +2350,7 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       fhirId,
       vid,
       pretty,
@@ -2385,9 +2377,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2401,9 +2393,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2415,9 +2407,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2429,9 +2421,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2444,9 +2436,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2458,9 +2450,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2472,9 +2464,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2487,9 +2479,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2500,9 +2492,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2514,9 +2506,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2528,9 +2520,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2544,9 +2536,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2562,9 +2554,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2579,9 +2571,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2598,9 +2590,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2625,9 +2617,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2641,9 +2633,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2655,9 +2647,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2669,9 +2661,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2684,9 +2676,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2698,9 +2690,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2712,9 +2704,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2727,9 +2719,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2740,9 +2732,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2754,9 +2746,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2768,9 +2760,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2784,9 +2776,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2802,9 +2794,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2819,9 +2811,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2838,9 +2830,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2865,9 +2857,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2881,9 +2873,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2895,9 +2887,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2909,9 +2901,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2924,9 +2916,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2938,9 +2930,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2952,9 +2944,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2967,9 +2959,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2980,9 +2972,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2994,9 +2986,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3008,9 +3000,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3024,9 +3016,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3042,9 +3034,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3059,9 +3051,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3078,9 +3070,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -3186,9 +3178,9 @@ abstract class FhirVReadRequest extends FhirRequest {
       required final R4ResourceType type,
       required final String fhirId,
       required final FhirId vid,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -3215,17 +3207,16 @@ abstract class FhirVReadRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -3273,9 +3264,9 @@ abstract class _$$FhirUpdateRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -3297,9 +3288,9 @@ class __$$FhirUpdateRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -3316,18 +3307,18 @@ class __$$FhirUpdateRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -3362,9 +3353,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
   const _$FhirUpdateRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -3389,20 +3380,17 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -3521,9 +3509,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3537,9 +3525,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3551,9 +3539,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3565,9 +3553,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3580,9 +3568,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3594,9 +3582,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3608,9 +3596,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -3623,9 +3611,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3636,9 +3624,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -3650,9 +3638,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3664,9 +3652,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3680,9 +3668,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3698,9 +3686,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3715,9 +3703,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3734,9 +3722,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -3761,9 +3749,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3777,9 +3765,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3791,9 +3779,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3805,9 +3793,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3820,9 +3808,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3834,9 +3822,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3848,9 +3836,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -3863,9 +3851,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3876,9 +3864,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -3890,9 +3878,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3904,9 +3892,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3920,9 +3908,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3938,9 +3926,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3955,9 +3943,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3974,9 +3962,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4001,9 +3989,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4017,9 +4005,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4031,9 +4019,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4045,9 +4033,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4060,9 +4048,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4074,9 +4062,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4088,9 +4076,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4103,9 +4091,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4116,9 +4104,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -4130,9 +4118,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4144,9 +4132,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4160,9 +4148,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4178,9 +4166,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4195,9 +4183,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4214,9 +4202,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4320,9 +4308,9 @@ abstract class FhirUpdateRequest extends FhirRequest {
   const factory FhirUpdateRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -4343,17 +4331,16 @@ abstract class FhirUpdateRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -4401,9 +4388,9 @@ abstract class _$$FhirPatchRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -4425,9 +4412,9 @@ class __$$FhirPatchRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -4444,18 +4431,18 @@ class __$$FhirPatchRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -4490,9 +4477,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
   const _$FhirPatchRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -4517,20 +4504,17 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -4649,9 +4633,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4665,9 +4649,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4679,9 +4663,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4693,9 +4677,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4708,9 +4692,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4722,9 +4706,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4736,9 +4720,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4751,9 +4735,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4764,9 +4748,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -4778,9 +4762,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4792,9 +4776,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4808,9 +4792,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4826,9 +4810,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4843,9 +4827,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4862,9 +4846,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4889,9 +4873,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4905,9 +4889,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4919,9 +4903,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4933,9 +4917,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4948,9 +4932,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4962,9 +4946,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4976,9 +4960,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4991,9 +4975,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5004,9 +4988,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5018,9 +5002,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5032,9 +5016,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5048,9 +5032,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5066,9 +5050,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5083,9 +5067,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5102,9 +5086,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -5129,9 +5113,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5145,9 +5129,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5159,9 +5143,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5173,9 +5157,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5188,9 +5172,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5202,9 +5186,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5216,9 +5200,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -5231,9 +5215,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5244,9 +5228,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5258,9 +5242,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5272,9 +5256,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5288,9 +5272,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5306,9 +5290,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5323,9 +5307,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5342,9 +5326,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -5448,9 +5432,9 @@ abstract class FhirPatchRequest extends FhirRequest {
   const factory FhirPatchRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -5471,17 +5455,16 @@ abstract class FhirPatchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -5530,9 +5513,9 @@ abstract class _$$FhirDeleteRequestImplCopyWith<$Res>
       {Uri base,
       R4ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -5553,11 +5536,11 @@ class __$$FhirDeleteRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
+    Object? type = freezed,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -5570,7 +5553,7 @@ class __$$FhirDeleteRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as R4ResourceType,
@@ -5578,18 +5561,18 @@ class __$$FhirDeleteRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -5625,9 +5608,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -5658,20 +5641,17 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -5745,7 +5725,7 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirDeleteRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.fhirId, fhirId) || other.fhirId == fhirId) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
@@ -5765,7 +5745,7 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       fhirId,
       pretty,
       summary,
@@ -5791,9 +5771,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5807,9 +5787,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5821,9 +5801,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5835,9 +5815,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5850,9 +5830,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5864,9 +5844,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5878,9 +5858,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -5893,9 +5873,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5906,9 +5886,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5920,9 +5900,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5934,9 +5914,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5950,9 +5930,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5968,9 +5948,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5985,9 +5965,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6004,9 +5984,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6031,9 +6011,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6047,9 +6027,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6061,9 +6041,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6075,9 +6055,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6090,9 +6070,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6104,9 +6084,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6118,9 +6098,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -6133,9 +6113,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6146,9 +6126,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -6160,9 +6140,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6174,9 +6154,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6190,9 +6170,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6208,9 +6188,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6225,9 +6205,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6244,9 +6224,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6271,9 +6251,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6287,9 +6267,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6301,9 +6281,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6315,9 +6295,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6330,9 +6310,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6344,9 +6324,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6358,9 +6338,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -6373,9 +6353,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6386,9 +6366,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -6400,9 +6380,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6414,9 +6394,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6430,9 +6410,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6448,9 +6428,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6465,9 +6445,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6484,9 +6464,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6591,9 +6571,9 @@ abstract class FhirDeleteRequest extends FhirRequest {
       {required final Uri base,
       required final R4ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -6619,17 +6599,16 @@ abstract class FhirDeleteRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -6677,9 +6656,9 @@ abstract class _$$FhirCreateRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -6701,9 +6680,9 @@ class __$$FhirCreateRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -6720,18 +6699,18 @@ class __$$FhirCreateRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -6766,9 +6745,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
   const _$FhirCreateRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -6793,20 +6772,17 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -6925,9 +6901,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6941,9 +6917,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6955,9 +6931,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6969,9 +6945,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6984,9 +6960,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6998,9 +6974,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7012,9 +6988,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7027,9 +7003,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7040,9 +7016,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7054,9 +7030,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7068,9 +7044,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7084,9 +7060,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7102,9 +7078,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7119,9 +7095,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7138,9 +7114,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7165,9 +7141,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7181,9 +7157,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7195,9 +7171,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7209,9 +7185,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7224,9 +7200,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7238,9 +7214,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7252,9 +7228,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7267,9 +7243,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7280,9 +7256,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7294,9 +7270,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7308,9 +7284,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7324,9 +7300,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7342,9 +7318,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7359,9 +7335,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7378,9 +7354,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7405,9 +7381,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7421,9 +7397,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7435,9 +7411,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7449,9 +7425,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7464,9 +7440,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7478,9 +7454,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7492,9 +7468,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7507,9 +7483,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7520,9 +7496,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7534,9 +7510,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7548,9 +7524,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7564,9 +7540,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7582,9 +7558,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7599,9 +7575,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7618,9 +7594,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7724,9 +7700,9 @@ abstract class FhirCreateRequest extends FhirRequest {
   const factory FhirCreateRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -7747,17 +7723,16 @@ abstract class FhirCreateRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -7805,9 +7780,9 @@ abstract class _$$FhirSearchRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       R4ResourceType type,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       bool usePost,
@@ -7830,10 +7805,10 @@ class __$$FhirSearchRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
-    Object? pretty = null,
+    Object? type = freezed,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? usePost = null,
@@ -7848,22 +7823,22 @@ class __$$FhirSearchRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as R4ResourceType,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -7906,9 +7881,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
   const _$FhirSearchRequestImpl(
       {required this.base,
       required this.type,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.usePost = false,
@@ -7937,20 +7912,17 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -8033,7 +8005,7 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirSearchRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
             (identical(other.format, format) || other.format == format) &&
@@ -8055,7 +8027,7 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       pretty,
       summary,
       format,
@@ -8082,9 +8054,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8098,9 +8070,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8112,9 +8084,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8126,9 +8098,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8141,9 +8113,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8155,9 +8127,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8169,9 +8141,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8184,9 +8156,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8197,9 +8169,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8211,9 +8183,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8225,9 +8197,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8241,9 +8213,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8259,9 +8231,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8276,9 +8248,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8295,9 +8267,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8322,9 +8294,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8338,9 +8310,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8352,9 +8324,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8366,9 +8338,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8381,9 +8353,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8395,9 +8367,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8409,9 +8381,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8424,9 +8396,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8437,9 +8409,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8451,9 +8423,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8465,9 +8437,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8481,9 +8453,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8499,9 +8471,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8516,9 +8488,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8535,9 +8507,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8562,9 +8534,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8578,9 +8550,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8592,9 +8564,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8606,9 +8578,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8621,9 +8593,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8635,9 +8607,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8649,9 +8621,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8664,9 +8636,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8677,9 +8649,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8691,9 +8663,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8705,9 +8677,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8721,9 +8693,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8739,9 +8711,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8756,9 +8728,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8775,9 +8747,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8881,9 +8853,9 @@ abstract class FhirSearchRequest extends FhirRequest {
   const factory FhirSearchRequest(
       {required final Uri base,
       required final R4ResourceType type,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final bool usePost,
@@ -8908,17 +8880,16 @@ abstract class FhirSearchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -8970,9 +8941,9 @@ abstract class _$$FhirSearchAllRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -8993,9 +8964,9 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -9008,18 +8979,18 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -9053,9 +9024,9 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
 class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
   const _$FhirSearchAllRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -9078,20 +9049,17 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -9208,9 +9176,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9224,9 +9192,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9238,9 +9206,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9252,9 +9220,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9267,9 +9235,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9281,9 +9249,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9295,9 +9263,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9310,9 +9278,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9323,9 +9291,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9337,9 +9305,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9351,9 +9319,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9367,9 +9335,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9385,9 +9353,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9402,9 +9370,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9421,9 +9389,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -9448,9 +9416,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9464,9 +9432,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9478,9 +9446,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9492,9 +9460,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9507,9 +9475,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9521,9 +9489,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9535,9 +9503,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9550,9 +9518,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9563,9 +9531,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9577,9 +9545,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9591,9 +9559,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9607,9 +9575,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9625,9 +9593,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9642,9 +9610,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9661,9 +9629,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -9688,9 +9656,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9704,9 +9672,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9718,9 +9686,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9732,9 +9700,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9747,9 +9715,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9761,9 +9729,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9775,9 +9743,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9790,9 +9758,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9803,9 +9771,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9817,9 +9785,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9831,9 +9799,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9847,9 +9815,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9865,9 +9833,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9882,9 +9850,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9901,9 +9869,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10006,9 +9974,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
 abstract class FhirSearchAllRequest extends FhirRequest {
   const factory FhirSearchAllRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -10028,17 +9996,16 @@ abstract class FhirSearchAllRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -10086,9 +10053,9 @@ abstract class _$$FhirCapabilitiesRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Mode mode,
@@ -10111,9 +10078,9 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mode = null,
@@ -10127,18 +10094,18 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -10176,9 +10143,9 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
 class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
   const _$FhirCapabilitiesRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mode = Mode.full,
@@ -10202,20 +10169,17 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -10338,9 +10302,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10354,9 +10318,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10368,9 +10332,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10382,9 +10346,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10397,9 +10361,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10411,9 +10375,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10425,9 +10389,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10440,9 +10404,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10453,9 +10417,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10467,9 +10431,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10481,9 +10445,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10497,9 +10461,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10515,9 +10479,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10532,9 +10496,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10551,9 +10515,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10578,9 +10542,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10594,9 +10558,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10608,9 +10572,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10622,9 +10586,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10637,9 +10601,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10651,9 +10615,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10665,9 +10629,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10680,9 +10644,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10693,9 +10657,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10707,9 +10671,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10721,9 +10685,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10737,9 +10701,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10755,9 +10719,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10772,9 +10736,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10791,9 +10755,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10818,9 +10782,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10834,9 +10798,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10848,9 +10812,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10862,9 +10826,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10877,9 +10841,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10891,9 +10855,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10905,9 +10869,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10920,9 +10884,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10933,9 +10897,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10947,9 +10911,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10961,9 +10925,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10977,9 +10941,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10995,9 +10959,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11012,9 +10976,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11031,9 +10995,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11136,9 +11100,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
 abstract class FhirCapabilitiesRequest extends FhirRequest {
   const factory FhirCapabilitiesRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final Mode mode,
@@ -11159,17 +11123,16 @@ abstract class FhirCapabilitiesRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -11220,9 +11183,9 @@ abstract class _$$FhirTransactionRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Bundle bundle,
@@ -11230,8 +11193,6 @@ abstract class _$$FhirTransactionRequestImplCopyWith<$Res>
       String accept,
       @JsonKey(includeFromJson: false, includeToJson: false) Client? client,
       Map<String, String>? headers});
-
-  $BundleCopyWith<$Res> get bundle;
 }
 
 /// @nodoc
@@ -11247,12 +11208,12 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
-    Object? bundle = null,
+    Object? bundle = freezed,
     Object? mimeType = freezed,
     Object? accept = null,
     Object? client = freezed,
@@ -11263,18 +11224,18 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -11283,7 +11244,7 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
           ? _value._parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      bundle: null == bundle
+      bundle: freezed == bundle
           ? _value.bundle
           : bundle // ignore: cast_nullable_to_non_nullable
               as Bundle,
@@ -11305,14 +11266,6 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
               as Map<String, String>?,
     ));
   }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $BundleCopyWith<$Res> get bundle {
-    return $BundleCopyWith<$Res>(_value.bundle, (value) {
-      return _then(_value.copyWith(bundle: value));
-    });
-  }
 }
 
 /// @nodoc
@@ -11320,9 +11273,9 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
 class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
   const _$FhirTransactionRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       required this.bundle,
@@ -11346,20 +11299,17 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -11443,7 +11393,7 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             const DeepCollectionEquality().equals(other._elements, _elements) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
-            (identical(other.bundle, bundle) || other.bundle == bundle) &&
+            const DeepCollectionEquality().equals(other.bundle, bundle) &&
             (identical(other.mimeType, mimeType) ||
                 other.mimeType == mimeType) &&
             (identical(other.accept, accept) || other.accept == accept) &&
@@ -11461,7 +11411,7 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
       format,
       const DeepCollectionEquality().hash(_elements),
       const DeepCollectionEquality().hash(_parameters),
-      bundle,
+      const DeepCollectionEquality().hash(bundle),
       mimeType,
       accept,
       client,
@@ -11481,9 +11431,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11497,9 +11447,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11511,9 +11461,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11525,9 +11475,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11540,9 +11490,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11554,9 +11504,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11568,9 +11518,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -11583,9 +11533,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11596,9 +11546,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -11610,9 +11560,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11624,9 +11574,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11640,9 +11590,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11658,9 +11608,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11675,9 +11625,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11694,9 +11644,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11721,9 +11671,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11737,9 +11687,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11751,9 +11701,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11765,9 +11715,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11780,9 +11730,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11794,9 +11744,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11808,9 +11758,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -11823,9 +11773,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11836,9 +11786,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -11850,9 +11800,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11864,9 +11814,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11880,9 +11830,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11898,9 +11848,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11915,9 +11865,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11934,9 +11884,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11961,9 +11911,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11977,9 +11927,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11991,9 +11941,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12005,9 +11955,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12020,9 +11970,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12034,9 +11984,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12048,9 +11998,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12063,9 +12013,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12076,9 +12026,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12090,9 +12040,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12104,9 +12054,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12120,9 +12070,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12138,9 +12088,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12155,9 +12105,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12174,9 +12124,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -12279,9 +12229,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
 abstract class FhirTransactionRequest extends FhirRequest {
   const factory FhirTransactionRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       required final Bundle bundle,
@@ -12302,17 +12252,16 @@ abstract class FhirTransactionRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -12362,9 +12311,9 @@ abstract class _$$FhirBatchRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Bundle bundle,
@@ -12372,8 +12321,6 @@ abstract class _$$FhirBatchRequestImplCopyWith<$Res>
       String accept,
       @JsonKey(includeFromJson: false, includeToJson: false) Client? client,
       Map<String, String>? headers});
-
-  $BundleCopyWith<$Res> get bundle;
 }
 
 /// @nodoc
@@ -12388,12 +12335,12 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
-    Object? bundle = null,
+    Object? bundle = freezed,
     Object? mimeType = freezed,
     Object? accept = null,
     Object? client = freezed,
@@ -12404,18 +12351,18 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -12424,7 +12371,7 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
           ? _value._parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      bundle: null == bundle
+      bundle: freezed == bundle
           ? _value.bundle
           : bundle // ignore: cast_nullable_to_non_nullable
               as Bundle,
@@ -12446,14 +12393,6 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
               as Map<String, String>?,
     ));
   }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $BundleCopyWith<$Res> get bundle {
-    return $BundleCopyWith<$Res>(_value.bundle, (value) {
-      return _then(_value.copyWith(bundle: value));
-    });
-  }
 }
 
 /// @nodoc
@@ -12461,9 +12400,9 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
 class _$FhirBatchRequestImpl extends FhirBatchRequest {
   const _$FhirBatchRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       required this.bundle,
@@ -12487,20 +12426,17 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -12584,7 +12520,7 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             const DeepCollectionEquality().equals(other._elements, _elements) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
-            (identical(other.bundle, bundle) || other.bundle == bundle) &&
+            const DeepCollectionEquality().equals(other.bundle, bundle) &&
             (identical(other.mimeType, mimeType) ||
                 other.mimeType == mimeType) &&
             (identical(other.accept, accept) || other.accept == accept) &&
@@ -12602,7 +12538,7 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
       format,
       const DeepCollectionEquality().hash(_elements),
       const DeepCollectionEquality().hash(_parameters),
-      bundle,
+      const DeepCollectionEquality().hash(bundle),
       mimeType,
       accept,
       client,
@@ -12622,9 +12558,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12638,9 +12574,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12652,9 +12588,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12666,9 +12602,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12681,9 +12617,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12695,9 +12631,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12709,9 +12645,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12724,9 +12660,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12737,9 +12673,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12751,9 +12687,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12765,9 +12701,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12781,9 +12717,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12799,9 +12735,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12816,9 +12752,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12835,9 +12771,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -12862,9 +12798,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12878,9 +12814,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12892,9 +12828,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12906,9 +12842,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12921,9 +12857,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12935,9 +12871,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12949,9 +12885,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12964,9 +12900,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12977,9 +12913,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12991,9 +12927,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13005,9 +12941,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13021,9 +12957,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13039,9 +12975,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13056,9 +12992,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13075,9 +13011,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -13102,9 +13038,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13118,9 +13054,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13132,9 +13068,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13146,9 +13082,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13161,9 +13097,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13175,9 +13111,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13189,9 +13125,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -13204,9 +13140,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13217,9 +13153,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -13231,9 +13167,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13245,9 +13181,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13261,9 +13197,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13279,9 +13215,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13296,9 +13232,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13315,9 +13251,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -13420,9 +13356,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
 abstract class FhirBatchRequest extends FhirRequest {
   const factory FhirBatchRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       required final Bundle bundle,
@@ -13443,17 +13379,16 @@ abstract class FhirBatchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -13505,9 +13440,9 @@ abstract class _$$FhirHistoryRequestImplCopyWith<$Res>
       {Uri base,
       R4ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -13532,11 +13467,11 @@ class __$$FhirHistoryRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
+    Object? type = freezed,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -13553,7 +13488,7 @@ class __$$FhirHistoryRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as R4ResourceType,
@@ -13561,18 +13496,18 @@ class __$$FhirHistoryRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -13624,9 +13559,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -13661,20 +13596,17 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -13769,7 +13701,7 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirHistoryRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.fhirId, fhirId) || other.fhirId == fhirId) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
@@ -13794,7 +13726,7 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       fhirId,
       pretty,
       summary,
@@ -13824,9 +13756,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13840,9 +13772,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13854,9 +13786,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13868,9 +13800,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13883,9 +13815,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13897,9 +13829,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13911,9 +13843,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -13926,9 +13858,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13939,9 +13871,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -13953,9 +13885,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13967,9 +13899,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13983,9 +13915,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14001,9 +13933,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14018,9 +13950,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14037,9 +13969,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14079,9 +14011,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14095,9 +14027,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14109,9 +14041,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14123,9 +14055,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14138,9 +14070,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14152,9 +14084,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14166,9 +14098,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -14181,9 +14113,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14194,9 +14126,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -14208,9 +14140,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14222,9 +14154,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14238,9 +14170,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14256,9 +14188,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14273,9 +14205,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14292,9 +14224,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14334,9 +14266,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14350,9 +14282,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14364,9 +14296,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14378,9 +14310,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14393,9 +14325,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14407,9 +14339,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14421,9 +14353,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -14436,9 +14368,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14449,9 +14381,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -14463,9 +14395,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14477,9 +14409,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14493,9 +14425,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14511,9 +14443,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14528,9 +14460,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14547,9 +14479,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14669,9 +14601,9 @@ abstract class FhirHistoryRequest extends FhirRequest {
       {required final Uri base,
       required final R4ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -14701,17 +14633,16 @@ abstract class FhirHistoryRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -14777,9 +14708,9 @@ abstract class _$$FhirHistoryTypeRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       R4ResourceType type,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -14805,10 +14736,10 @@ class __$$FhirHistoryTypeRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? type = null,
-    Object? pretty = null,
+    Object? type = freezed,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -14825,22 +14756,22 @@ class __$$FhirHistoryTypeRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      type: null == type
+      type: freezed == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as R4ResourceType,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -14891,9 +14822,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
   const _$FhirHistoryTypeRequestImpl(
       {required this.base,
       required this.type,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -14924,20 +14855,17 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -15032,7 +14960,7 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirHistoryTypeRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
             (identical(other.format, format) || other.format == format) &&
@@ -15056,7 +14984,7 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       pretty,
       summary,
       format,
@@ -15085,9 +15013,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15101,9 +15029,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15115,9 +15043,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15129,9 +15057,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15144,9 +15072,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15158,9 +15086,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15172,9 +15100,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15187,9 +15115,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15200,9 +15128,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15214,9 +15142,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15228,9 +15156,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15244,9 +15172,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15262,9 +15190,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15279,9 +15207,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15298,9 +15226,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15339,9 +15267,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15355,9 +15283,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15369,9 +15297,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15383,9 +15311,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15398,9 +15326,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15412,9 +15340,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15426,9 +15354,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15441,9 +15369,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15454,9 +15382,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15468,9 +15396,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15482,9 +15410,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15498,9 +15426,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15516,9 +15444,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15533,9 +15461,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15552,9 +15480,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15593,9 +15521,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15609,9 +15537,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15623,9 +15551,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15637,9 +15565,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15652,9 +15580,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15666,9 +15594,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15680,9 +15608,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15695,9 +15623,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15708,9 +15636,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15722,9 +15650,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15736,9 +15664,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15752,9 +15680,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15770,9 +15698,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15787,9 +15715,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15806,9 +15734,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15926,9 +15854,9 @@ abstract class FhirHistoryTypeRequest extends FhirRequest {
   const factory FhirHistoryTypeRequest(
       {required final Uri base,
       required final R4ResourceType type,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -15955,17 +15883,16 @@ abstract class FhirHistoryTypeRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -16030,9 +15957,9 @@ abstract class _$$FhirHistoryAllRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -16057,9 +15984,9 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -16076,18 +16003,18 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -16137,9 +16064,9 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
 class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
   const _$FhirHistoryAllRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -16166,20 +16093,17 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -16325,9 +16249,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16341,9 +16265,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16355,9 +16279,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16369,9 +16293,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16384,9 +16308,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16398,9 +16322,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16412,9 +16336,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16427,9 +16351,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16440,9 +16364,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16454,9 +16378,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16468,9 +16392,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16484,9 +16408,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16502,9 +16426,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16519,9 +16443,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16538,9 +16462,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -16565,9 +16489,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16581,9 +16505,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16595,9 +16519,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16609,9 +16533,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16624,9 +16548,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16638,9 +16562,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16652,9 +16576,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16667,9 +16591,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16680,9 +16604,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16694,9 +16618,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16708,9 +16632,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16724,9 +16648,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16742,9 +16666,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16759,9 +16683,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16778,9 +16702,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -16805,9 +16729,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16821,9 +16745,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16835,9 +16759,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16849,9 +16773,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16864,9 +16788,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16878,9 +16802,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16892,9 +16816,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16907,9 +16831,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16920,9 +16844,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16934,9 +16858,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16948,9 +16872,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16964,9 +16888,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16982,9 +16906,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16999,9 +16923,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17018,9 +16942,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -17123,9 +17047,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
 abstract class FhirHistoryAllRequest extends FhirRequest {
   const factory FhirHistoryAllRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -17149,17 +17073,16 @@ abstract class FhirHistoryAllRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -17225,9 +17148,9 @@ abstract class _$$FhirOperationRequestImplCopyWith<$Res>
       {Uri base,
       R4ResourceType? type,
       String? fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Parameters? fhirParameter,
@@ -17238,8 +17161,6 @@ abstract class _$$FhirOperationRequestImplCopyWith<$Res>
       String accept,
       @JsonKey(includeFromJson: false, includeToJson: false) Client? client,
       Map<String, String>? headers});
-
-  $ParametersCopyWith<$Res>? get fhirParameter;
 }
 
 /// @nodoc
@@ -17256,9 +17177,9 @@ class __$$FhirOperationRequestImplCopyWithImpl<$Res>
     Object? base = null,
     Object? type = freezed,
     Object? fhirId = freezed,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? fhirParameter = freezed,
@@ -17283,18 +17204,18 @@ class __$$FhirOperationRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String?,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -17337,18 +17258,6 @@ class __$$FhirOperationRequestImplCopyWithImpl<$Res>
               as Map<String, String>?,
     ));
   }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $ParametersCopyWith<$Res>? get fhirParameter {
-    if (_value.fhirParameter == null) {
-      return null;
-    }
-
-    return $ParametersCopyWith<$Res>(_value.fhirParameter!, (value) {
-      return _then(_value.copyWith(fhirParameter: value));
-    });
-  }
 }
 
 /// @nodoc
@@ -17358,9 +17267,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
       {required this.base,
       this.type,
       this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.fhirParameter,
@@ -17391,20 +17300,17 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -17493,7 +17399,7 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         (other.runtimeType == runtimeType &&
             other is _$FhirOperationRequestImpl &&
             (identical(other.base, base) || other.base == base) &&
-            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other.type, type) &&
             (identical(other.fhirId, fhirId) || other.fhirId == fhirId) &&
             (identical(other.pretty, pretty) || other.pretty == pretty) &&
             (identical(other.summary, summary) || other.summary == summary) &&
@@ -17501,8 +17407,8 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             const DeepCollectionEquality().equals(other._elements, _elements) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
-            (identical(other.fhirParameter, fhirParameter) ||
-                other.fhirParameter == fhirParameter) &&
+            const DeepCollectionEquality()
+                .equals(other.fhirParameter, fhirParameter) &&
             (identical(other.operation, operation) ||
                 other.operation == operation) &&
             (identical(other.usePost, usePost) || other.usePost == usePost) &&
@@ -17520,14 +17426,14 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
   int get hashCode => Object.hash(
       runtimeType,
       base,
-      type,
+      const DeepCollectionEquality().hash(type),
       fhirId,
       pretty,
       summary,
       format,
       const DeepCollectionEquality().hash(_elements),
       const DeepCollectionEquality().hash(_parameters),
-      fhirParameter,
+      const DeepCollectionEquality().hash(fhirParameter),
       operation,
       usePost,
       useFormData,
@@ -17551,9 +17457,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17567,9 +17473,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17581,9 +17487,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17595,9 +17501,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17610,9 +17516,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17624,9 +17530,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17638,9 +17544,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -17653,9 +17559,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17666,9 +17572,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -17680,9 +17586,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17694,9 +17600,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17710,9 +17616,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17728,9 +17634,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17745,9 +17651,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17764,9 +17670,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -17806,9 +17712,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17822,9 +17728,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17836,9 +17742,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17850,9 +17756,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17865,9 +17771,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17879,9 +17785,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17893,9 +17799,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -17908,9 +17814,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17921,9 +17827,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -17935,9 +17841,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17949,9 +17855,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17965,9 +17871,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17983,9 +17889,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18000,9 +17906,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18019,9 +17925,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -18061,9 +17967,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18077,9 +17983,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             R4ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18091,9 +17997,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18105,9 +18011,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18120,9 +18026,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18134,9 +18040,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18148,9 +18054,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -18163,9 +18069,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18176,9 +18082,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -18190,9 +18096,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -18204,9 +18110,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -18220,9 +18126,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18238,9 +18144,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             R4ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18255,9 +18161,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18274,9 +18180,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R4ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -18396,9 +18302,9 @@ abstract class FhirOperationRequest extends FhirRequest {
       {required final Uri base,
       final R4ResourceType? type,
       final String? fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final Parameters? fhirParameter,
@@ -18424,17 +18330,16 @@ abstract class FhirOperationRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in

--- a/lib/r4/fhir_request.g.dart
+++ b/lib/r4/fhir_request.g.dart
@@ -12,10 +12,10 @@ _$FhirReadRequestImpl _$$FhirReadRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$R4ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -226,10 +226,10 @@ _$FhirVReadRequestImpl _$$FhirVReadRequestImplFromJson(
       type: $enumDecode(_$R4ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
       vid: FhirId.fromJson(json['vid']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -278,10 +278,10 @@ _$FhirUpdateRequestImpl _$$FhirUpdateRequestImplFromJson(
     _$FhirUpdateRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -328,10 +328,10 @@ _$FhirPatchRequestImpl _$$FhirPatchRequestImplFromJson(
     _$FhirPatchRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -379,10 +379,10 @@ _$FhirDeleteRequestImpl _$$FhirDeleteRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$R4ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -430,10 +430,10 @@ _$FhirCreateRequestImpl _$$FhirCreateRequestImplFromJson(
     _$FhirCreateRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -480,10 +480,10 @@ _$FhirSearchRequestImpl _$$FhirSearchRequestImplFromJson(
     _$FhirSearchRequestImpl(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$R4ResourceTypeEnumMap, json['type']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -543,10 +543,10 @@ _$FhirSearchAllRequestImpl _$$FhirSearchAllRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirSearchAllRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -591,10 +591,10 @@ _$FhirCapabilitiesRequestImpl _$$FhirCapabilitiesRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirCapabilitiesRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -647,10 +647,10 @@ _$FhirTransactionRequestImpl _$$FhirTransactionRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirTransactionRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -697,10 +697,10 @@ _$FhirBatchRequestImpl _$$FhirBatchRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirBatchRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -749,10 +749,10 @@ _$FhirHistoryRequestImpl _$$FhirHistoryRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$R4ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -812,10 +812,10 @@ _$FhirHistoryTypeRequestImpl _$$FhirHistoryTypeRequestImplFromJson(
     _$FhirHistoryTypeRequestImpl(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$R4ResourceTypeEnumMap, json['type']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -873,10 +873,10 @@ _$FhirHistoryAllRequestImpl _$$FhirHistoryAllRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirHistoryAllRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -935,10 +935,10 @@ _$FhirOperationRequestImpl _$$FhirOperationRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecodeNullable(_$R4ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String?,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??

--- a/lib/r5/fhir_request.dart
+++ b/lib/r5/fhir_request.dart
@@ -46,15 +46,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -107,15 +106,14 @@ class FhirRequest with _$FhirRequest {
     required FhirId vid,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -159,15 +157,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -211,15 +208,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -270,15 +266,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -322,15 +317,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -379,15 +373,14 @@ class FhirRequest with _$FhirRequest {
     required R5ResourceType type,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -435,15 +428,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -487,15 +479,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -542,15 +533,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -597,15 +587,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -668,15 +657,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -749,15 +737,14 @@ class FhirRequest with _$FhirRequest {
     required R5ResourceType type,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -826,15 +813,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -900,15 +886,14 @@ class FhirRequest with _$FhirRequest {
     String? fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -1586,13 +1571,13 @@ class FhirRequest with _$FhirRequest {
       orElse: () => '');
 
   /// specifies the format
-  String _format({bool join = false}) => maybeMap(
+  String _format({bool join = false}) => format == null ? '' : maybeMap(
       capabilities: (FhirCapabilitiesRequest request) =>
           _encodeParam('_format=${request.format}'),
       orElse: () => _encodeParam('_format=$format', join: join));
 
   /// assigns if you want it pretty
-  String _pretty({bool join = true}) =>
+  String _pretty({bool join = true}) => pretty == null ? '' :
       _encodeParam('_pretty=$pretty', join: join);
 
   /// assigns if you want the summary

--- a/lib/r5/fhir_request.dart
+++ b/lib/r5/fhir_request.dart
@@ -51,7 +51,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -111,7 +111,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -162,7 +162,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -213,7 +213,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -271,7 +271,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -322,7 +322,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -378,7 +378,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -433,7 +433,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -484,7 +484,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -538,7 +538,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -592,7 +592,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -662,7 +662,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -742,7 +742,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -818,7 +818,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -891,7 +891,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -1571,14 +1571,16 @@ class FhirRequest with _$FhirRequest {
       orElse: () => '');
 
   /// specifies the format
-  String _format({bool join = false}) => format == null ? '' : maybeMap(
-      capabilities: (FhirCapabilitiesRequest request) =>
-          _encodeParam('_format=${request.format}'),
-      orElse: () => _encodeParam('_format=$format', join: join));
+  String _format({bool join = false}) => format == null
+      ? ''
+      : maybeMap(
+          capabilities: (FhirCapabilitiesRequest request) =>
+              _encodeParam('_format=${request.format}'),
+          orElse: () => _encodeParam('_format=$format', join: join));
 
   /// assigns if you want it pretty
-  String _pretty({bool join = true}) => pretty == null ? '' :
-      _encodeParam('_pretty=$pretty', join: join);
+  String _pretty({bool join = true}) =>
+      pretty == null ? '' : _encodeParam('_pretty=$pretty', join: join);
 
   /// assigns if you want the summary
   String _summary({bool join = true}) => summary != Summary.none

--- a/lib/r5/fhir_request.freezed.dart
+++ b/lib/r5/fhir_request.freezed.dart
@@ -59,15 +59,14 @@ mixin _$FhirRequest {
   Uri get base => throw _privateConstructorUsedError;
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty => throw _privateConstructorUsedError;
+  bool? get pretty => throw _privateConstructorUsedError;
 
   /// [summary] - do you want the result to be a summary
   Summary get summary => throw _privateConstructorUsedError;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format => throw _privateConstructorUsedError;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format => throw _privateConstructorUsedError;
 
   /// [elements] - elements you need to pass in
   List<String> get elements => throw _privateConstructorUsedError;
@@ -98,9 +97,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -114,9 +113,9 @@ mixin _$FhirRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -128,9 +127,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -142,9 +141,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -157,9 +156,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -171,9 +170,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -185,9 +184,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -200,9 +199,9 @@ mixin _$FhirRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -213,9 +212,9 @@ mixin _$FhirRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -227,9 +226,9 @@ mixin _$FhirRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -241,9 +240,9 @@ mixin _$FhirRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -257,9 +256,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -275,9 +274,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -292,9 +291,9 @@ mixin _$FhirRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -311,9 +310,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -334,9 +333,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -350,9 +349,9 @@ mixin _$FhirRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -364,9 +363,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -378,9 +377,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -393,9 +392,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -407,9 +406,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -421,9 +420,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -436,9 +435,9 @@ mixin _$FhirRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -449,9 +448,9 @@ mixin _$FhirRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -463,9 +462,9 @@ mixin _$FhirRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -477,9 +476,9 @@ mixin _$FhirRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -493,9 +492,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -511,9 +510,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -528,9 +527,9 @@ mixin _$FhirRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -547,9 +546,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -570,9 +569,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -586,9 +585,9 @@ mixin _$FhirRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -600,9 +599,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -614,9 +613,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -629,9 +628,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -643,9 +642,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -657,9 +656,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -672,9 +671,9 @@ mixin _$FhirRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -685,9 +684,9 @@ mixin _$FhirRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -699,9 +698,9 @@ mixin _$FhirRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -713,9 +712,9 @@ mixin _$FhirRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -729,9 +728,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -747,9 +746,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -764,9 +763,9 @@ mixin _$FhirRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -783,9 +782,9 @@ mixin _$FhirRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -873,9 +872,9 @@ abstract class $FhirRequestCopyWith<$Res> {
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -898,9 +897,9 @@ class _$FhirRequestCopyWithImpl<$Res, $Val extends FhirRequest>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -913,18 +912,18 @@ class _$FhirRequestCopyWithImpl<$Res, $Val extends FhirRequest>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value.elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -965,9 +964,9 @@ abstract class _$$FhirReadRequestImplCopyWith<$Res>
       {Uri base,
       R5ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -990,9 +989,9 @@ class __$$FhirReadRequestImplCopyWithImpl<$Res>
     Object? base = null,
     Object? type = null,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -1013,18 +1012,18 @@ class __$$FhirReadRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -1060,9 +1059,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -1093,20 +1092,17 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -1226,9 +1222,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1242,9 +1238,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1256,9 +1252,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1270,9 +1266,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1285,9 +1281,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1299,9 +1295,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1313,9 +1309,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1328,9 +1324,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1341,9 +1337,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1355,9 +1351,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1369,9 +1365,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1385,9 +1381,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1403,9 +1399,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1420,9 +1416,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1439,9 +1435,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -1466,9 +1462,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1482,9 +1478,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1496,9 +1492,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1510,9 +1506,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1525,9 +1521,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1539,9 +1535,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1553,9 +1549,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1568,9 +1564,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1581,9 +1577,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1595,9 +1591,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1609,9 +1605,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1625,9 +1621,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1643,9 +1639,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1660,9 +1656,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1679,9 +1675,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -1706,9 +1702,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1722,9 +1718,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1736,9 +1732,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1750,9 +1746,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1765,9 +1761,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1779,9 +1775,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1793,9 +1789,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1808,9 +1804,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1821,9 +1817,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1835,9 +1831,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1849,9 +1845,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1865,9 +1861,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1883,9 +1879,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1900,9 +1896,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1919,9 +1915,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2026,9 +2022,9 @@ abstract class FhirReadRequest extends FhirRequest {
       {required final Uri base,
       required final R5ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -2054,17 +2050,16 @@ abstract class FhirReadRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -2114,9 +2109,9 @@ abstract class _$$FhirVReadRequestImplCopyWith<$Res>
       R5ResourceType type,
       String fhirId,
       FhirId vid,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -2140,9 +2135,9 @@ class __$$FhirVReadRequestImplCopyWithImpl<$Res>
     Object? type = null,
     Object? fhirId = null,
     Object? vid = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -2167,18 +2162,18 @@ class __$$FhirVReadRequestImplCopyWithImpl<$Res>
           ? _value.vid
           : vid // ignore: cast_nullable_to_non_nullable
               as FhirId,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -2215,9 +2210,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
       required this.type,
       required this.fhirId,
       required this.vid,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -2250,20 +2245,17 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -2385,9 +2377,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2401,9 +2393,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2415,9 +2407,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2429,9 +2421,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2444,9 +2436,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2458,9 +2450,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2472,9 +2464,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2487,9 +2479,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2500,9 +2492,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2514,9 +2506,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2528,9 +2520,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2544,9 +2536,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2562,9 +2554,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2579,9 +2571,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2598,9 +2590,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2625,9 +2617,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2641,9 +2633,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2655,9 +2647,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2669,9 +2661,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2684,9 +2676,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2698,9 +2690,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2712,9 +2704,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2727,9 +2719,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2740,9 +2732,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2754,9 +2746,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2768,9 +2760,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2784,9 +2776,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2802,9 +2794,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2819,9 +2811,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2838,9 +2830,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2865,9 +2857,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2881,9 +2873,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2895,9 +2887,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2909,9 +2901,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2924,9 +2916,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2938,9 +2930,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2952,9 +2944,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2967,9 +2959,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2980,9 +2972,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2994,9 +2986,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3008,9 +3000,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3024,9 +3016,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3042,9 +3034,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3059,9 +3051,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3078,9 +3070,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -3186,9 +3178,9 @@ abstract class FhirVReadRequest extends FhirRequest {
       required final R5ResourceType type,
       required final String fhirId,
       required final FhirId vid,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -3215,17 +3207,16 @@ abstract class FhirVReadRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -3273,9 +3264,9 @@ abstract class _$$FhirUpdateRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -3297,9 +3288,9 @@ class __$$FhirUpdateRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -3316,18 +3307,18 @@ class __$$FhirUpdateRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -3362,9 +3353,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
   const _$FhirUpdateRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -3389,20 +3380,17 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -3521,9 +3509,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3537,9 +3525,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3551,9 +3539,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3565,9 +3553,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3580,9 +3568,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3594,9 +3582,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3608,9 +3596,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -3623,9 +3611,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3636,9 +3624,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -3650,9 +3638,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3664,9 +3652,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3680,9 +3668,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3698,9 +3686,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3715,9 +3703,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3734,9 +3722,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -3761,9 +3749,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3777,9 +3765,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3791,9 +3779,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3805,9 +3793,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3820,9 +3808,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3834,9 +3822,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3848,9 +3836,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -3863,9 +3851,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3876,9 +3864,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -3890,9 +3878,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3904,9 +3892,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3920,9 +3908,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3938,9 +3926,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3955,9 +3943,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3974,9 +3962,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4001,9 +3989,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4017,9 +4005,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4031,9 +4019,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4045,9 +4033,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4060,9 +4048,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4074,9 +4062,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4088,9 +4076,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4103,9 +4091,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4116,9 +4104,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -4130,9 +4118,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4144,9 +4132,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4160,9 +4148,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4178,9 +4166,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4195,9 +4183,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4214,9 +4202,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4320,9 +4308,9 @@ abstract class FhirUpdateRequest extends FhirRequest {
   const factory FhirUpdateRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -4343,17 +4331,16 @@ abstract class FhirUpdateRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -4401,9 +4388,9 @@ abstract class _$$FhirPatchRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -4425,9 +4412,9 @@ class __$$FhirPatchRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -4444,18 +4431,18 @@ class __$$FhirPatchRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -4490,9 +4477,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
   const _$FhirPatchRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -4517,20 +4504,17 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -4649,9 +4633,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4665,9 +4649,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4679,9 +4663,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4693,9 +4677,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4708,9 +4692,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4722,9 +4706,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4736,9 +4720,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4751,9 +4735,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4764,9 +4748,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -4778,9 +4762,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4792,9 +4776,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4808,9 +4792,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4826,9 +4810,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4843,9 +4827,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4862,9 +4846,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4889,9 +4873,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4905,9 +4889,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4919,9 +4903,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4933,9 +4917,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4948,9 +4932,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4962,9 +4946,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4976,9 +4960,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4991,9 +4975,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5004,9 +4988,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5018,9 +5002,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5032,9 +5016,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5048,9 +5032,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5066,9 +5050,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5083,9 +5067,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5102,9 +5086,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -5129,9 +5113,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5145,9 +5129,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5159,9 +5143,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5173,9 +5157,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5188,9 +5172,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5202,9 +5186,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5216,9 +5200,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -5231,9 +5215,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5244,9 +5228,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5258,9 +5242,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5272,9 +5256,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5288,9 +5272,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5306,9 +5290,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5323,9 +5307,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5342,9 +5326,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -5448,9 +5432,9 @@ abstract class FhirPatchRequest extends FhirRequest {
   const factory FhirPatchRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -5471,17 +5455,16 @@ abstract class FhirPatchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -5530,9 +5513,9 @@ abstract class _$$FhirDeleteRequestImplCopyWith<$Res>
       {Uri base,
       R5ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -5555,9 +5538,9 @@ class __$$FhirDeleteRequestImplCopyWithImpl<$Res>
     Object? base = null,
     Object? type = null,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -5578,18 +5561,18 @@ class __$$FhirDeleteRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -5625,9 +5608,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -5658,20 +5641,17 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -5791,9 +5771,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5807,9 +5787,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5821,9 +5801,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5835,9 +5815,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5850,9 +5830,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5864,9 +5844,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5878,9 +5858,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -5893,9 +5873,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5906,9 +5886,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5920,9 +5900,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5934,9 +5914,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5950,9 +5930,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5968,9 +5948,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5985,9 +5965,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6004,9 +5984,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6031,9 +6011,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6047,9 +6027,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6061,9 +6041,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6075,9 +6055,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6090,9 +6070,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6104,9 +6084,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6118,9 +6098,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -6133,9 +6113,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6146,9 +6126,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -6160,9 +6140,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6174,9 +6154,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6190,9 +6170,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6208,9 +6188,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6225,9 +6205,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6244,9 +6224,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6271,9 +6251,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6287,9 +6267,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6301,9 +6281,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6315,9 +6295,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6330,9 +6310,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6344,9 +6324,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6358,9 +6338,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -6373,9 +6353,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6386,9 +6366,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -6400,9 +6380,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6414,9 +6394,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6430,9 +6410,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6448,9 +6428,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6465,9 +6445,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6484,9 +6464,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6591,9 +6571,9 @@ abstract class FhirDeleteRequest extends FhirRequest {
       {required final Uri base,
       required final R5ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -6619,17 +6599,16 @@ abstract class FhirDeleteRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -6677,9 +6656,9 @@ abstract class _$$FhirCreateRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -6701,9 +6680,9 @@ class __$$FhirCreateRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -6720,18 +6699,18 @@ class __$$FhirCreateRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -6766,9 +6745,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
   const _$FhirCreateRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -6793,20 +6772,17 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -6925,9 +6901,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6941,9 +6917,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6955,9 +6931,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6969,9 +6945,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6984,9 +6960,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6998,9 +6974,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7012,9 +6988,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7027,9 +7003,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7040,9 +7016,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7054,9 +7030,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7068,9 +7044,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7084,9 +7060,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7102,9 +7078,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7119,9 +7095,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7138,9 +7114,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7165,9 +7141,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7181,9 +7157,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7195,9 +7171,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7209,9 +7185,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7224,9 +7200,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7238,9 +7214,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7252,9 +7228,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7267,9 +7243,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7280,9 +7256,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7294,9 +7270,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7308,9 +7284,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7324,9 +7300,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7342,9 +7318,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7359,9 +7335,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7378,9 +7354,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7405,9 +7381,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7421,9 +7397,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7435,9 +7411,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7449,9 +7425,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7464,9 +7440,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7478,9 +7454,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7492,9 +7468,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7507,9 +7483,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7520,9 +7496,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7534,9 +7510,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7548,9 +7524,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7564,9 +7540,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7582,9 +7558,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7599,9 +7575,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7618,9 +7594,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7724,9 +7700,9 @@ abstract class FhirCreateRequest extends FhirRequest {
   const factory FhirCreateRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -7747,17 +7723,16 @@ abstract class FhirCreateRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -7805,9 +7780,9 @@ abstract class _$$FhirSearchRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       R5ResourceType type,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       bool usePost,
@@ -7831,9 +7806,9 @@ class __$$FhirSearchRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? type = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? usePost = null,
@@ -7852,18 +7827,18 @@ class __$$FhirSearchRequestImplCopyWithImpl<$Res>
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as R5ResourceType,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -7906,9 +7881,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
   const _$FhirSearchRequestImpl(
       {required this.base,
       required this.type,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.usePost = false,
@@ -7937,20 +7912,17 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -8082,9 +8054,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8098,9 +8070,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8112,9 +8084,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8126,9 +8098,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8141,9 +8113,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8155,9 +8127,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8169,9 +8141,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8184,9 +8156,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8197,9 +8169,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8211,9 +8183,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8225,9 +8197,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8241,9 +8213,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8259,9 +8231,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8276,9 +8248,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8295,9 +8267,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8322,9 +8294,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8338,9 +8310,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8352,9 +8324,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8366,9 +8338,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8381,9 +8353,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8395,9 +8367,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8409,9 +8381,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8424,9 +8396,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8437,9 +8409,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8451,9 +8423,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8465,9 +8437,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8481,9 +8453,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8499,9 +8471,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8516,9 +8488,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8535,9 +8507,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8562,9 +8534,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8578,9 +8550,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8592,9 +8564,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8606,9 +8578,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8621,9 +8593,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8635,9 +8607,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8649,9 +8621,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8664,9 +8636,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8677,9 +8649,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8691,9 +8663,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8705,9 +8677,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8721,9 +8693,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8739,9 +8711,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8756,9 +8728,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8775,9 +8747,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8881,9 +8853,9 @@ abstract class FhirSearchRequest extends FhirRequest {
   const factory FhirSearchRequest(
       {required final Uri base,
       required final R5ResourceType type,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final bool usePost,
@@ -8908,17 +8880,16 @@ abstract class FhirSearchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -8970,9 +8941,9 @@ abstract class _$$FhirSearchAllRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -8993,9 +8964,9 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -9008,18 +8979,18 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -9053,9 +9024,9 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
 class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
   const _$FhirSearchAllRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -9078,20 +9049,17 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -9208,9 +9176,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9224,9 +9192,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9238,9 +9206,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9252,9 +9220,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9267,9 +9235,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9281,9 +9249,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9295,9 +9263,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9310,9 +9278,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9323,9 +9291,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9337,9 +9305,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9351,9 +9319,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9367,9 +9335,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9385,9 +9353,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9402,9 +9370,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9421,9 +9389,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -9448,9 +9416,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9464,9 +9432,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9478,9 +9446,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9492,9 +9460,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9507,9 +9475,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9521,9 +9489,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9535,9 +9503,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9550,9 +9518,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9563,9 +9531,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9577,9 +9545,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9591,9 +9559,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9607,9 +9575,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9625,9 +9593,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9642,9 +9610,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9661,9 +9629,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -9688,9 +9656,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9704,9 +9672,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9718,9 +9686,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9732,9 +9700,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9747,9 +9715,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9761,9 +9729,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9775,9 +9743,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9790,9 +9758,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9803,9 +9771,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9817,9 +9785,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9831,9 +9799,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9847,9 +9815,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9865,9 +9833,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9882,9 +9850,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9901,9 +9869,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10006,9 +9974,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
 abstract class FhirSearchAllRequest extends FhirRequest {
   const factory FhirSearchAllRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -10028,17 +9996,16 @@ abstract class FhirSearchAllRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -10086,9 +10053,9 @@ abstract class _$$FhirCapabilitiesRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Mode mode,
@@ -10111,9 +10078,9 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mode = null,
@@ -10127,18 +10094,18 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -10176,9 +10143,9 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
 class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
   const _$FhirCapabilitiesRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mode = Mode.full,
@@ -10202,20 +10169,17 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -10338,9 +10302,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10354,9 +10318,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10368,9 +10332,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10382,9 +10346,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10397,9 +10361,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10411,9 +10375,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10425,9 +10389,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10440,9 +10404,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10453,9 +10417,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10467,9 +10431,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10481,9 +10445,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10497,9 +10461,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10515,9 +10479,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10532,9 +10496,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10551,9 +10515,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10578,9 +10542,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10594,9 +10558,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10608,9 +10572,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10622,9 +10586,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10637,9 +10601,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10651,9 +10615,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10665,9 +10629,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10680,9 +10644,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10693,9 +10657,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10707,9 +10671,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10721,9 +10685,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10737,9 +10701,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10755,9 +10719,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10772,9 +10736,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10791,9 +10755,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10818,9 +10782,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10834,9 +10798,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10848,9 +10812,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10862,9 +10826,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10877,9 +10841,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10891,9 +10855,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10905,9 +10869,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10920,9 +10884,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10933,9 +10897,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10947,9 +10911,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10961,9 +10925,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10977,9 +10941,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10995,9 +10959,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11012,9 +10976,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11031,9 +10995,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11136,9 +11100,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
 abstract class FhirCapabilitiesRequest extends FhirRequest {
   const factory FhirCapabilitiesRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final Mode mode,
@@ -11159,17 +11123,16 @@ abstract class FhirCapabilitiesRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -11220,9 +11183,9 @@ abstract class _$$FhirTransactionRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Bundle bundle,
@@ -11247,9 +11210,9 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? bundle = null,
@@ -11263,18 +11226,18 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -11320,9 +11283,9 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
 class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
   const _$FhirTransactionRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       required this.bundle,
@@ -11346,20 +11309,17 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -11481,9 +11441,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11497,9 +11457,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11511,9 +11471,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11525,9 +11485,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11540,9 +11500,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11554,9 +11514,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11568,9 +11528,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -11583,9 +11543,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11596,9 +11556,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -11610,9 +11570,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11624,9 +11584,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11640,9 +11600,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11658,9 +11618,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11675,9 +11635,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11694,9 +11654,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11721,9 +11681,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11737,9 +11697,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11751,9 +11711,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11765,9 +11725,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11780,9 +11740,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11794,9 +11754,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11808,9 +11768,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -11823,9 +11783,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11836,9 +11796,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -11850,9 +11810,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11864,9 +11824,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11880,9 +11840,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11898,9 +11858,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11915,9 +11875,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11934,9 +11894,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11961,9 +11921,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11977,9 +11937,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11991,9 +11951,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12005,9 +11965,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12020,9 +11980,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12034,9 +11994,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12048,9 +12008,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12063,9 +12023,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12076,9 +12036,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12090,9 +12050,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12104,9 +12064,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12120,9 +12080,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12138,9 +12098,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12155,9 +12115,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12174,9 +12134,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -12279,9 +12239,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
 abstract class FhirTransactionRequest extends FhirRequest {
   const factory FhirTransactionRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       required final Bundle bundle,
@@ -12302,17 +12262,16 @@ abstract class FhirTransactionRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -12362,9 +12321,9 @@ abstract class _$$FhirBatchRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Bundle bundle,
@@ -12388,9 +12347,9 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? bundle = null,
@@ -12404,18 +12363,18 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -12461,9 +12420,9 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
 class _$FhirBatchRequestImpl extends FhirBatchRequest {
   const _$FhirBatchRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       required this.bundle,
@@ -12487,20 +12446,17 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -12622,9 +12578,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12638,9 +12594,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12652,9 +12608,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12666,9 +12622,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12681,9 +12637,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12695,9 +12651,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12709,9 +12665,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12724,9 +12680,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12737,9 +12693,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12751,9 +12707,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12765,9 +12721,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12781,9 +12737,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12799,9 +12755,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12816,9 +12772,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12835,9 +12791,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -12862,9 +12818,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12878,9 +12834,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12892,9 +12848,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12906,9 +12862,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12921,9 +12877,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12935,9 +12891,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12949,9 +12905,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12964,9 +12920,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12977,9 +12933,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12991,9 +12947,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13005,9 +12961,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13021,9 +12977,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13039,9 +12995,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13056,9 +13012,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13075,9 +13031,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -13102,9 +13058,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13118,9 +13074,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13132,9 +13088,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13146,9 +13102,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13161,9 +13117,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13175,9 +13131,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13189,9 +13145,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -13204,9 +13160,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13217,9 +13173,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -13231,9 +13187,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13245,9 +13201,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13261,9 +13217,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13279,9 +13235,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13296,9 +13252,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13315,9 +13271,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -13420,9 +13376,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
 abstract class FhirBatchRequest extends FhirRequest {
   const factory FhirBatchRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       required final Bundle bundle,
@@ -13443,17 +13399,16 @@ abstract class FhirBatchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -13505,9 +13460,9 @@ abstract class _$$FhirHistoryRequestImplCopyWith<$Res>
       {Uri base,
       R5ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -13534,9 +13489,9 @@ class __$$FhirHistoryRequestImplCopyWithImpl<$Res>
     Object? base = null,
     Object? type = null,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -13561,18 +13516,18 @@ class __$$FhirHistoryRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -13624,9 +13579,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -13661,20 +13616,17 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -13824,9 +13776,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13840,9 +13792,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13854,9 +13806,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13868,9 +13820,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13883,9 +13835,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13897,9 +13849,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13911,9 +13863,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -13926,9 +13878,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13939,9 +13891,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -13953,9 +13905,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13967,9 +13919,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13983,9 +13935,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14001,9 +13953,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14018,9 +13970,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14037,9 +13989,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14079,9 +14031,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14095,9 +14047,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14109,9 +14061,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14123,9 +14075,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14138,9 +14090,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14152,9 +14104,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14166,9 +14118,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -14181,9 +14133,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14194,9 +14146,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -14208,9 +14160,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14222,9 +14174,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14238,9 +14190,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14256,9 +14208,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14273,9 +14225,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14292,9 +14244,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14334,9 +14286,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14350,9 +14302,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14364,9 +14316,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14378,9 +14330,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14393,9 +14345,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14407,9 +14359,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14421,9 +14373,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -14436,9 +14388,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14449,9 +14401,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -14463,9 +14415,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14477,9 +14429,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14493,9 +14445,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14511,9 +14463,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14528,9 +14480,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14547,9 +14499,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14669,9 +14621,9 @@ abstract class FhirHistoryRequest extends FhirRequest {
       {required final Uri base,
       required final R5ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -14701,17 +14653,16 @@ abstract class FhirHistoryRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -14777,9 +14728,9 @@ abstract class _$$FhirHistoryTypeRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       R5ResourceType type,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -14806,9 +14757,9 @@ class __$$FhirHistoryTypeRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? type = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -14829,18 +14780,18 @@ class __$$FhirHistoryTypeRequestImplCopyWithImpl<$Res>
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as R5ResourceType,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -14891,9 +14842,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
   const _$FhirHistoryTypeRequestImpl(
       {required this.base,
       required this.type,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -14924,20 +14875,17 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -15085,9 +15033,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15101,9 +15049,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15115,9 +15063,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15129,9 +15077,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15144,9 +15092,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15158,9 +15106,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15172,9 +15120,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15187,9 +15135,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15200,9 +15148,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15214,9 +15162,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15228,9 +15176,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15244,9 +15192,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15262,9 +15210,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15279,9 +15227,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15298,9 +15246,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15339,9 +15287,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15355,9 +15303,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15369,9 +15317,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15383,9 +15331,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15398,9 +15346,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15412,9 +15360,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15426,9 +15374,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15441,9 +15389,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15454,9 +15402,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15468,9 +15416,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15482,9 +15430,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15498,9 +15446,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15516,9 +15464,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15533,9 +15481,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15552,9 +15500,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15593,9 +15541,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15609,9 +15557,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15623,9 +15571,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15637,9 +15585,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15652,9 +15600,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15666,9 +15614,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15680,9 +15628,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15695,9 +15643,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15708,9 +15656,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15722,9 +15670,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15736,9 +15684,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15752,9 +15700,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15770,9 +15718,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15787,9 +15735,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15806,9 +15754,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15926,9 +15874,9 @@ abstract class FhirHistoryTypeRequest extends FhirRequest {
   const factory FhirHistoryTypeRequest(
       {required final Uri base,
       required final R5ResourceType type,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -15955,17 +15903,16 @@ abstract class FhirHistoryTypeRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -16030,9 +15977,9 @@ abstract class _$$FhirHistoryAllRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -16057,9 +16004,9 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -16076,18 +16023,18 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -16137,9 +16084,9 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
 class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
   const _$FhirHistoryAllRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -16166,20 +16113,17 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -16325,9 +16269,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16341,9 +16285,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16355,9 +16299,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16369,9 +16313,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16384,9 +16328,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16398,9 +16342,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16412,9 +16356,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16427,9 +16371,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16440,9 +16384,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16454,9 +16398,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16468,9 +16412,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16484,9 +16428,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16502,9 +16446,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16519,9 +16463,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16538,9 +16482,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -16565,9 +16509,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16581,9 +16525,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16595,9 +16539,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16609,9 +16553,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16624,9 +16568,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16638,9 +16582,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16652,9 +16596,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16667,9 +16611,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16680,9 +16624,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16694,9 +16638,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16708,9 +16652,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16724,9 +16668,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16742,9 +16686,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16759,9 +16703,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16778,9 +16722,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -16805,9 +16749,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16821,9 +16765,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16835,9 +16779,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16849,9 +16793,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16864,9 +16808,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16878,9 +16822,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16892,9 +16836,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16907,9 +16851,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16920,9 +16864,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16934,9 +16878,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16948,9 +16892,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16964,9 +16908,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16982,9 +16926,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16999,9 +16943,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17018,9 +16962,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -17123,9 +17067,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
 abstract class FhirHistoryAllRequest extends FhirRequest {
   const factory FhirHistoryAllRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -17149,17 +17093,16 @@ abstract class FhirHistoryAllRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -17225,9 +17168,9 @@ abstract class _$$FhirOperationRequestImplCopyWith<$Res>
       {Uri base,
       R5ResourceType? type,
       String? fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Parameters? fhirParameter,
@@ -17256,9 +17199,9 @@ class __$$FhirOperationRequestImplCopyWithImpl<$Res>
     Object? base = null,
     Object? type = freezed,
     Object? fhirId = freezed,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? fhirParameter = freezed,
@@ -17283,18 +17226,18 @@ class __$$FhirOperationRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String?,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -17358,9 +17301,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
       {required this.base,
       this.type,
       this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.fhirParameter,
@@ -17391,20 +17334,17 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -17551,9 +17491,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17567,9 +17507,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17581,9 +17521,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17595,9 +17535,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17610,9 +17550,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17624,9 +17564,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17638,9 +17578,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -17653,9 +17593,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17666,9 +17606,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -17680,9 +17620,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17694,9 +17634,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17710,9 +17650,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17728,9 +17668,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17745,9 +17685,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17764,9 +17704,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -17806,9 +17746,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17822,9 +17762,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17836,9 +17776,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17850,9 +17790,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17865,9 +17805,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17879,9 +17819,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17893,9 +17833,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -17908,9 +17848,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17921,9 +17861,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -17935,9 +17875,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17949,9 +17889,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17965,9 +17905,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17983,9 +17923,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18000,9 +17940,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18019,9 +17959,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -18061,9 +18001,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18077,9 +18017,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             R5ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18091,9 +18031,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18105,9 +18045,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18120,9 +18060,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18134,9 +18074,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18148,9 +18088,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -18163,9 +18103,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18176,9 +18116,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -18190,9 +18130,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -18204,9 +18144,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -18220,9 +18160,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18238,9 +18178,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             R5ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18255,9 +18195,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18274,9 +18214,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             R5ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -18396,9 +18336,9 @@ abstract class FhirOperationRequest extends FhirRequest {
       {required final Uri base,
       final R5ResourceType? type,
       final String? fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final Parameters? fhirParameter,
@@ -18424,17 +18364,16 @@ abstract class FhirOperationRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in

--- a/lib/r5/fhir_request.g.dart
+++ b/lib/r5/fhir_request.g.dart
@@ -12,10 +12,10 @@ _$FhirReadRequestImpl _$$FhirReadRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$R5ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -38,11 +38,6 @@ Map<String, dynamic> _$$FhirReadRequestImplToJson(
     'base': instance.base.toString(),
     'type': _$R5ResourceTypeEnumMap[instance.type]!,
     'fhirId': instance.fhirId,
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -51,6 +46,11 @@ Map<String, dynamic> _$$FhirReadRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
   writeNotNull('mimeType', _$MimeTypeEnumMap[instance.mimeType]);
   val['accept'] = instance.accept;
   writeNotNull('headers', instance.headers);
@@ -244,10 +244,10 @@ _$FhirVReadRequestImpl _$$FhirVReadRequestImplFromJson(
       type: $enumDecode(_$R5ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
       vid: FhirId.fromJson(json['vid']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -271,11 +271,6 @@ Map<String, dynamic> _$$FhirVReadRequestImplToJson(
     'type': _$R5ResourceTypeEnumMap[instance.type]!,
     'fhirId': instance.fhirId,
     'vid': instance.vid.toJson(),
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -284,6 +279,11 @@ Map<String, dynamic> _$$FhirVReadRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
   writeNotNull('mimeType', _$MimeTypeEnumMap[instance.mimeType]);
   val['accept'] = instance.accept;
   writeNotNull('headers', instance.headers);
@@ -296,10 +296,10 @@ _$FhirUpdateRequestImpl _$$FhirUpdateRequestImplFromJson(
     _$FhirUpdateRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -321,11 +321,6 @@ Map<String, dynamic> _$$FhirUpdateRequestImplToJson(
   final val = <String, dynamic>{
     'base': instance.base.toString(),
     'resource': instance.resource.toJson(),
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -334,6 +329,11 @@ Map<String, dynamic> _$$FhirUpdateRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
   writeNotNull('mimeType', _$MimeTypeEnumMap[instance.mimeType]);
   val['accept'] = instance.accept;
   writeNotNull('headers', instance.headers);
@@ -346,10 +346,10 @@ _$FhirPatchRequestImpl _$$FhirPatchRequestImplFromJson(
     _$FhirPatchRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -371,11 +371,6 @@ Map<String, dynamic> _$$FhirPatchRequestImplToJson(
   final val = <String, dynamic>{
     'base': instance.base.toString(),
     'resource': instance.resource.toJson(),
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -384,6 +379,11 @@ Map<String, dynamic> _$$FhirPatchRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
   writeNotNull('mimeType', _$MimeTypeEnumMap[instance.mimeType]);
   val['accept'] = instance.accept;
   writeNotNull('headers', instance.headers);
@@ -397,10 +397,10 @@ _$FhirDeleteRequestImpl _$$FhirDeleteRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$R5ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -423,11 +423,6 @@ Map<String, dynamic> _$$FhirDeleteRequestImplToJson(
     'base': instance.base.toString(),
     'type': _$R5ResourceTypeEnumMap[instance.type]!,
     'fhirId': instance.fhirId,
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -436,6 +431,11 @@ Map<String, dynamic> _$$FhirDeleteRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
   writeNotNull('mimeType', _$MimeTypeEnumMap[instance.mimeType]);
   val['accept'] = instance.accept;
   writeNotNull('headers', instance.headers);
@@ -448,10 +448,10 @@ _$FhirCreateRequestImpl _$$FhirCreateRequestImplFromJson(
     _$FhirCreateRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -473,11 +473,6 @@ Map<String, dynamic> _$$FhirCreateRequestImplToJson(
   final val = <String, dynamic>{
     'base': instance.base.toString(),
     'resource': instance.resource.toJson(),
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -486,6 +481,11 @@ Map<String, dynamic> _$$FhirCreateRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
   writeNotNull('mimeType', _$MimeTypeEnumMap[instance.mimeType]);
   val['accept'] = instance.accept;
   writeNotNull('headers', instance.headers);
@@ -498,10 +498,10 @@ _$FhirSearchRequestImpl _$$FhirSearchRequestImplFromJson(
     _$FhirSearchRequestImpl(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$R5ResourceTypeEnumMap, json['type']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -527,13 +527,6 @@ Map<String, dynamic> _$$FhirSearchRequestImplToJson(
   final val = <String, dynamic>{
     'base': instance.base.toString(),
     'type': _$R5ResourceTypeEnumMap[instance.type]!,
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
-    'usePost': instance.usePost,
-    'restfulRequest': _$RestfulRequestEnumMap[instance.restfulRequest]!,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -542,6 +535,13 @@ Map<String, dynamic> _$$FhirSearchRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
+  val['usePost'] = instance.usePost;
+  val['restfulRequest'] = _$RestfulRequestEnumMap[instance.restfulRequest]!;
   writeNotNull('mimeType', _$MimeTypeEnumMap[instance.mimeType]);
   val['accept'] = instance.accept;
   writeNotNull('headers', instance.headers);
@@ -561,10 +561,10 @@ _$FhirSearchAllRequestImpl _$$FhirSearchAllRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirSearchAllRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -585,11 +585,6 @@ Map<String, dynamic> _$$FhirSearchAllRequestImplToJson(
     _$FhirSearchAllRequestImpl instance) {
   final val = <String, dynamic>{
     'base': instance.base.toString(),
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -598,6 +593,11 @@ Map<String, dynamic> _$$FhirSearchAllRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
   writeNotNull('mimeType', _$MimeTypeEnumMap[instance.mimeType]);
   val['accept'] = instance.accept;
   writeNotNull('headers', instance.headers);
@@ -609,10 +609,10 @@ _$FhirCapabilitiesRequestImpl _$$FhirCapabilitiesRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirCapabilitiesRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -634,12 +634,6 @@ Map<String, dynamic> _$$FhirCapabilitiesRequestImplToJson(
     _$FhirCapabilitiesRequestImpl instance) {
   final val = <String, dynamic>{
     'base': instance.base.toString(),
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
-    'mode': _$ModeEnumMap[instance.mode]!,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -648,6 +642,12 @@ Map<String, dynamic> _$$FhirCapabilitiesRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
+  val['mode'] = _$ModeEnumMap[instance.mode]!;
   writeNotNull('mimeType', _$MimeTypeEnumMap[instance.mimeType]);
   val['accept'] = instance.accept;
   writeNotNull('headers', instance.headers);
@@ -665,10 +665,10 @@ _$FhirTransactionRequestImpl _$$FhirTransactionRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirTransactionRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -690,12 +690,6 @@ Map<String, dynamic> _$$FhirTransactionRequestImplToJson(
     _$FhirTransactionRequestImpl instance) {
   final val = <String, dynamic>{
     'base': instance.base.toString(),
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
-    'bundle': instance.bundle.toJson(),
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -704,6 +698,12 @@ Map<String, dynamic> _$$FhirTransactionRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
+  val['bundle'] = instance.bundle.toJson();
   writeNotNull('mimeType', _$MimeTypeEnumMap[instance.mimeType]);
   val['accept'] = instance.accept;
   writeNotNull('headers', instance.headers);
@@ -715,10 +715,10 @@ _$FhirBatchRequestImpl _$$FhirBatchRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirBatchRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -740,12 +740,6 @@ Map<String, dynamic> _$$FhirBatchRequestImplToJson(
     _$FhirBatchRequestImpl instance) {
   final val = <String, dynamic>{
     'base': instance.base.toString(),
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
-    'bundle': instance.bundle.toJson(),
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -754,6 +748,12 @@ Map<String, dynamic> _$$FhirBatchRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
+  val['bundle'] = instance.bundle.toJson();
   writeNotNull('mimeType', _$MimeTypeEnumMap[instance.mimeType]);
   val['accept'] = instance.accept;
   writeNotNull('headers', instance.headers);
@@ -767,10 +767,10 @@ _$FhirHistoryRequestImpl _$$FhirHistoryRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$R5ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -801,11 +801,6 @@ Map<String, dynamic> _$$FhirHistoryRequestImplToJson(
     'base': instance.base.toString(),
     'type': _$R5ResourceTypeEnumMap[instance.type]!,
     'fhirId': instance.fhirId,
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -814,6 +809,11 @@ Map<String, dynamic> _$$FhirHistoryRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
   writeNotNull('count', instance.count);
   writeNotNull('since', instance.since?.toJson());
   writeNotNull('at', instance.at?.toJson());
@@ -830,10 +830,10 @@ _$FhirHistoryTypeRequestImpl _$$FhirHistoryTypeRequestImplFromJson(
     _$FhirHistoryTypeRequestImpl(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$R5ResourceTypeEnumMap, json['type']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -863,11 +863,6 @@ Map<String, dynamic> _$$FhirHistoryTypeRequestImplToJson(
   final val = <String, dynamic>{
     'base': instance.base.toString(),
     'type': _$R5ResourceTypeEnumMap[instance.type]!,
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -876,6 +871,11 @@ Map<String, dynamic> _$$FhirHistoryTypeRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
   writeNotNull('count', instance.count);
   writeNotNull('since', instance.since?.toJson());
   writeNotNull('at', instance.at?.toJson());
@@ -891,10 +891,10 @@ _$FhirHistoryAllRequestImpl _$$FhirHistoryAllRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirHistoryAllRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -923,11 +923,6 @@ Map<String, dynamic> _$$FhirHistoryAllRequestImplToJson(
     _$FhirHistoryAllRequestImpl instance) {
   final val = <String, dynamic>{
     'base': instance.base.toString(),
-    'pretty': instance.pretty,
-    'summary': _$SummaryEnumMap[instance.summary]!,
-    'format': instance.format,
-    'elements': instance.elements,
-    'parameters': instance.parameters,
   };
 
   void writeNotNull(String key, dynamic value) {
@@ -936,6 +931,11 @@ Map<String, dynamic> _$$FhirHistoryAllRequestImplToJson(
     }
   }
 
+  writeNotNull('pretty', instance.pretty);
+  val['summary'] = _$SummaryEnumMap[instance.summary]!;
+  writeNotNull('format', instance.format);
+  val['elements'] = instance.elements;
+  val['parameters'] = instance.parameters;
   writeNotNull('count', instance.count);
   writeNotNull('since', instance.since?.toJson());
   writeNotNull('at', instance.at?.toJson());
@@ -953,10 +953,10 @@ _$FhirOperationRequestImpl _$$FhirOperationRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecodeNullable(_$R5ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String?,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -993,9 +993,9 @@ Map<String, dynamic> _$$FhirOperationRequestImplToJson(
 
   writeNotNull('type', _$R5ResourceTypeEnumMap[instance.type]);
   writeNotNull('fhirId', instance.fhirId);
-  val['pretty'] = instance.pretty;
+  writeNotNull('pretty', instance.pretty);
   val['summary'] = _$SummaryEnumMap[instance.summary]!;
-  val['format'] = instance.format;
+  writeNotNull('format', instance.format);
   val['elements'] = instance.elements;
   val['parameters'] = instance.parameters;
   writeNotNull('fhirParameter', instance.fhirParameter?.toJson());

--- a/lib/stu3/fhir_request.dart
+++ b/lib/stu3/fhir_request.dart
@@ -46,15 +46,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -107,15 +106,14 @@ class FhirRequest with _$FhirRequest {
     required FhirId vid,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -159,15 +157,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -211,15 +208,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -270,15 +266,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -322,15 +317,14 @@ class FhirRequest with _$FhirRequest {
     required Resource resource,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -379,15 +373,14 @@ class FhirRequest with _$FhirRequest {
     required Stu3ResourceType type,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -435,15 +428,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -487,15 +479,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -542,15 +533,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -597,15 +587,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -668,15 +657,14 @@ class FhirRequest with _$FhirRequest {
     required String fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -749,15 +737,14 @@ class FhirRequest with _$FhirRequest {
     required Stu3ResourceType type,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -826,15 +813,14 @@ class FhirRequest with _$FhirRequest {
     required Uri base,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -900,15 +886,14 @@ class FhirRequest with _$FhirRequest {
     String? fhirId,
 
     /// [pretty] - pretty print the json formatting in the response
-    @Default(false) bool pretty,
+    bool? pretty,
 
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - currently requests json, but could consider requesting
-    ///   json+fhir or fhir+json (would not request XML as this library doesn't
-    ///   work with XML)
-    @Default('json') String format,
+    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// (would not request XML as this library doesn't work with XML)
+    String? format,
 
     /// [elements] - elements you need to pass in
     @Default(<String>[]) List<String> elements,
@@ -1586,13 +1571,13 @@ class FhirRequest with _$FhirRequest {
       orElse: () => '');
 
   /// specifies the format
-  String _format({bool join = false}) => maybeMap(
+  String _format({bool join = false}) => format == null ? '' : maybeMap(
       capabilities: (FhirCapabilitiesRequest request) =>
           _encodeParam('_format=${request.format}'),
       orElse: () => _encodeParam('_format=$format', join: join));
 
   /// assigns if you want it pretty
-  String _pretty({bool join = true}) =>
+  String _pretty({bool join = true}) => pretty == null ? '' :
       _encodeParam('_pretty=$pretty', join: join);
 
   /// assigns if you want the summary

--- a/lib/stu3/fhir_request.dart
+++ b/lib/stu3/fhir_request.dart
@@ -51,7 +51,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -111,7 +111,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -162,7 +162,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -213,7 +213,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -271,7 +271,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -322,7 +322,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -378,7 +378,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -433,7 +433,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -484,7 +484,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -538,7 +538,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -592,7 +592,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -662,7 +662,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -742,7 +742,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -818,7 +818,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -891,7 +891,7 @@ class FhirRequest with _$FhirRequest {
     /// [summary] - do you want the result to be a summary
     @Default(Summary.none) Summary summary,
 
-    /// [format] - Possible formats are: json, json+fhir or fhir+json 
+    /// [format] - Possible formats are: json, json+fhir or fhir+json
     /// (would not request XML as this library doesn't work with XML)
     String? format,
 
@@ -1571,14 +1571,16 @@ class FhirRequest with _$FhirRequest {
       orElse: () => '');
 
   /// specifies the format
-  String _format({bool join = false}) => format == null ? '' : maybeMap(
-      capabilities: (FhirCapabilitiesRequest request) =>
-          _encodeParam('_format=${request.format}'),
-      orElse: () => _encodeParam('_format=$format', join: join));
+  String _format({bool join = false}) => format == null
+      ? ''
+      : maybeMap(
+          capabilities: (FhirCapabilitiesRequest request) =>
+              _encodeParam('_format=${request.format}'),
+          orElse: () => _encodeParam('_format=$format', join: join));
 
   /// assigns if you want it pretty
-  String _pretty({bool join = true}) => pretty == null ? '' :
-      _encodeParam('_pretty=$pretty', join: join);
+  String _pretty({bool join = true}) =>
+      pretty == null ? '' : _encodeParam('_pretty=$pretty', join: join);
 
   /// assigns if you want the summary
   String _summary({bool join = true}) => summary != Summary.none
@@ -1781,7 +1783,7 @@ class FhirRequest with _$FhirRequest {
         if (result.statusCode == 200 || result.statusCode == 201) {
           return OperationOutcome(issue: <OperationOutcomeIssue>[
             OperationOutcomeIssue(
-               severity: OperationOutcomeIssueSeverity.information,
+                severity: OperationOutcomeIssueSeverity.information,
                 code: OperationOutcomeIssueCode.informational,
                 diagnostics: 'Your request succeeded with a status of '
                     '${result.statusCode}\n, but the request result did not have '
@@ -1800,7 +1802,7 @@ class FhirRequest with _$FhirRequest {
         } else {
           return OperationOutcome(issue: <OperationOutcomeIssue>[
             OperationOutcomeIssue(
-         severity: OperationOutcomeIssueSeverity.information,
+                severity: OperationOutcomeIssueSeverity.information,
                 code: OperationOutcomeIssueCode.informational,
                 diagnostics: 'Your request succeeded with a status of '
                     '${result.statusCode}\n, but the request result did not have '
@@ -1822,7 +1824,7 @@ class FhirRequest with _$FhirRequest {
         if (body?['resourceType'] == null) {
           return OperationOutcome(issue: <OperationOutcomeIssue>[
             OperationOutcomeIssue(
-          severity: OperationOutcomeIssueSeverity.error,
+              severity: OperationOutcomeIssueSeverity.error,
               code: OperationOutcomeIssueCode.unknown,
               details: const CodeableConcept(
                   text:
@@ -1842,7 +1844,7 @@ class FhirRequest with _$FhirRequest {
                 if (operationOutcome.issue.isNotEmpty)
                   ...operationOutcome.issue,
                 OperationOutcomeIssue(
-                 severity: OperationOutcomeIssueSeverity.error,
+                    severity: OperationOutcomeIssueSeverity.error,
                     code: OperationOutcomeIssueCode.unknown,
                     diagnostics:
                         'Status: ${body?['status']}\nMessage: ${body?['message']}\n'),
@@ -1856,7 +1858,7 @@ class FhirRequest with _$FhirRequest {
           if (newResource.resourceType == null) {
             return OperationOutcome(issue: <OperationOutcomeIssue>[
               OperationOutcomeIssue(
-                 severity: OperationOutcomeIssueSeverity.error,
+                severity: OperationOutcomeIssueSeverity.error,
                 code: OperationOutcomeIssueCode.unknown,
                 details: const CodeableConcept(
                     text: 'Request was made and seemed to return a Resource,\n'
@@ -1880,7 +1882,7 @@ class FhirRequest with _$FhirRequest {
   OperationOutcome _operationOutcome(String issue, {String? diagnostics}) =>
       OperationOutcome(issue: <OperationOutcomeIssue>[
         OperationOutcomeIssue(
-       severity: OperationOutcomeIssueSeverity.error,
+          severity: OperationOutcomeIssueSeverity.error,
           code: OperationOutcomeIssueCode.value,
           details: CodeableConcept(text: issue),
           diagnostics: diagnostics,

--- a/lib/stu3/fhir_request.freezed.dart
+++ b/lib/stu3/fhir_request.freezed.dart
@@ -59,15 +59,14 @@ mixin _$FhirRequest {
   Uri get base => throw _privateConstructorUsedError;
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty => throw _privateConstructorUsedError;
+  bool? get pretty => throw _privateConstructorUsedError;
 
   /// [summary] - do you want the result to be a summary
   Summary get summary => throw _privateConstructorUsedError;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format => throw _privateConstructorUsedError;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format => throw _privateConstructorUsedError;
 
   /// [elements] - elements you need to pass in
   List<String> get elements => throw _privateConstructorUsedError;
@@ -98,9 +97,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -114,9 +113,9 @@ mixin _$FhirRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -128,9 +127,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -142,9 +141,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -157,9 +156,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -171,9 +170,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -185,9 +184,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -200,9 +199,9 @@ mixin _$FhirRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -213,9 +212,9 @@ mixin _$FhirRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -227,9 +226,9 @@ mixin _$FhirRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -241,9 +240,9 @@ mixin _$FhirRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -257,9 +256,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -275,9 +274,9 @@ mixin _$FhirRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -292,9 +291,9 @@ mixin _$FhirRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -311,9 +310,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -334,9 +333,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -350,9 +349,9 @@ mixin _$FhirRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -364,9 +363,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -378,9 +377,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -393,9 +392,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -407,9 +406,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -421,9 +420,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -436,9 +435,9 @@ mixin _$FhirRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -449,9 +448,9 @@ mixin _$FhirRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -463,9 +462,9 @@ mixin _$FhirRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -477,9 +476,9 @@ mixin _$FhirRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -493,9 +492,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -511,9 +510,9 @@ mixin _$FhirRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -528,9 +527,9 @@ mixin _$FhirRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -547,9 +546,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -570,9 +569,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -586,9 +585,9 @@ mixin _$FhirRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -600,9 +599,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -614,9 +613,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -629,9 +628,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -643,9 +642,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -657,9 +656,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -672,9 +671,9 @@ mixin _$FhirRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -685,9 +684,9 @@ mixin _$FhirRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -699,9 +698,9 @@ mixin _$FhirRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -713,9 +712,9 @@ mixin _$FhirRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -729,9 +728,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -747,9 +746,9 @@ mixin _$FhirRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -764,9 +763,9 @@ mixin _$FhirRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -783,9 +782,9 @@ mixin _$FhirRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -873,9 +872,9 @@ abstract class $FhirRequestCopyWith<$Res> {
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -898,9 +897,9 @@ class _$FhirRequestCopyWithImpl<$Res, $Val extends FhirRequest>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -913,18 +912,18 @@ class _$FhirRequestCopyWithImpl<$Res, $Val extends FhirRequest>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value.elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -965,9 +964,9 @@ abstract class _$$FhirReadRequestImplCopyWith<$Res>
       {Uri base,
       Stu3ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -990,9 +989,9 @@ class __$$FhirReadRequestImplCopyWithImpl<$Res>
     Object? base = null,
     Object? type = null,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -1013,18 +1012,18 @@ class __$$FhirReadRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -1060,9 +1059,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -1093,20 +1092,17 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -1226,9 +1222,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1242,9 +1238,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1256,9 +1252,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1270,9 +1266,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1285,9 +1281,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1299,9 +1295,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1313,9 +1309,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1328,9 +1324,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1341,9 +1337,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1355,9 +1351,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1369,9 +1365,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1385,9 +1381,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1403,9 +1399,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1420,9 +1416,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1439,9 +1435,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -1466,9 +1462,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1482,9 +1478,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1496,9 +1492,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1510,9 +1506,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1525,9 +1521,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1539,9 +1535,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1553,9 +1549,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1568,9 +1564,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1581,9 +1577,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1595,9 +1591,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1609,9 +1605,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1625,9 +1621,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1643,9 +1639,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1660,9 +1656,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1679,9 +1675,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -1706,9 +1702,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1722,9 +1718,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1736,9 +1732,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1750,9 +1746,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1765,9 +1761,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1779,9 +1775,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1793,9 +1789,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -1808,9 +1804,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -1821,9 +1817,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -1835,9 +1831,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1849,9 +1845,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -1865,9 +1861,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1883,9 +1879,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1900,9 +1896,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -1919,9 +1915,9 @@ class _$FhirReadRequestImpl extends FhirReadRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2026,9 +2022,9 @@ abstract class FhirReadRequest extends FhirRequest {
       {required final Uri base,
       required final Stu3ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -2054,17 +2050,16 @@ abstract class FhirReadRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -2114,9 +2109,9 @@ abstract class _$$FhirVReadRequestImplCopyWith<$Res>
       Stu3ResourceType type,
       String fhirId,
       FhirId vid,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -2140,9 +2135,9 @@ class __$$FhirVReadRequestImplCopyWithImpl<$Res>
     Object? type = null,
     Object? fhirId = null,
     Object? vid = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -2167,18 +2162,18 @@ class __$$FhirVReadRequestImplCopyWithImpl<$Res>
           ? _value.vid
           : vid // ignore: cast_nullable_to_non_nullable
               as FhirId,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -2215,9 +2210,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
       required this.type,
       required this.fhirId,
       required this.vid,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -2250,20 +2245,17 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -2385,9 +2377,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2401,9 +2393,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2415,9 +2407,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2429,9 +2421,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2444,9 +2436,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2458,9 +2450,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2472,9 +2464,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2487,9 +2479,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2500,9 +2492,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2514,9 +2506,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2528,9 +2520,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2544,9 +2536,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2562,9 +2554,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2579,9 +2571,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2598,9 +2590,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2625,9 +2617,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2641,9 +2633,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2655,9 +2647,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2669,9 +2661,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2684,9 +2676,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2698,9 +2690,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2712,9 +2704,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2727,9 +2719,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2740,9 +2732,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2754,9 +2746,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2768,9 +2760,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -2784,9 +2776,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2802,9 +2794,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2819,9 +2811,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -2838,9 +2830,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -2865,9 +2857,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2881,9 +2873,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2895,9 +2887,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2909,9 +2901,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2924,9 +2916,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2938,9 +2930,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2952,9 +2944,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -2967,9 +2959,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -2980,9 +2972,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -2994,9 +2986,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3008,9 +3000,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3024,9 +3016,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3042,9 +3034,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3059,9 +3051,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3078,9 +3070,9 @@ class _$FhirVReadRequestImpl extends FhirVReadRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -3186,9 +3178,9 @@ abstract class FhirVReadRequest extends FhirRequest {
       required final Stu3ResourceType type,
       required final String fhirId,
       required final FhirId vid,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -3215,17 +3207,16 @@ abstract class FhirVReadRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -3273,9 +3264,9 @@ abstract class _$$FhirUpdateRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -3297,9 +3288,9 @@ class __$$FhirUpdateRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -3316,18 +3307,18 @@ class __$$FhirUpdateRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -3362,9 +3353,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
   const _$FhirUpdateRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -3389,20 +3380,17 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -3521,9 +3509,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3537,9 +3525,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3551,9 +3539,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3565,9 +3553,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3580,9 +3568,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3594,9 +3582,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3608,9 +3596,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -3623,9 +3611,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3636,9 +3624,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -3650,9 +3638,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3664,9 +3652,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3680,9 +3668,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3698,9 +3686,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3715,9 +3703,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3734,9 +3722,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -3761,9 +3749,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3777,9 +3765,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3791,9 +3779,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3805,9 +3793,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3820,9 +3808,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3834,9 +3822,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3848,9 +3836,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -3863,9 +3851,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -3876,9 +3864,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -3890,9 +3878,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3904,9 +3892,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -3920,9 +3908,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3938,9 +3926,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3955,9 +3943,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -3974,9 +3962,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4001,9 +3989,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4017,9 +4005,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4031,9 +4019,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4045,9 +4033,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4060,9 +4048,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4074,9 +4062,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4088,9 +4076,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4103,9 +4091,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4116,9 +4104,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -4130,9 +4118,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4144,9 +4132,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4160,9 +4148,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4178,9 +4166,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4195,9 +4183,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4214,9 +4202,9 @@ class _$FhirUpdateRequestImpl extends FhirUpdateRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4320,9 +4308,9 @@ abstract class FhirUpdateRequest extends FhirRequest {
   const factory FhirUpdateRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -4343,17 +4331,16 @@ abstract class FhirUpdateRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -4401,9 +4388,9 @@ abstract class _$$FhirPatchRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -4425,9 +4412,9 @@ class __$$FhirPatchRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -4444,18 +4431,18 @@ class __$$FhirPatchRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -4490,9 +4477,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
   const _$FhirPatchRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -4517,20 +4504,17 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -4649,9 +4633,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4665,9 +4649,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4679,9 +4663,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4693,9 +4677,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4708,9 +4692,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4722,9 +4706,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4736,9 +4720,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4751,9 +4735,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4764,9 +4748,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -4778,9 +4762,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4792,9 +4776,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -4808,9 +4792,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4826,9 +4810,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4843,9 +4827,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -4862,9 +4846,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -4889,9 +4873,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4905,9 +4889,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4919,9 +4903,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4933,9 +4917,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4948,9 +4932,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4962,9 +4946,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -4976,9 +4960,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -4991,9 +4975,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5004,9 +4988,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5018,9 +5002,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5032,9 +5016,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5048,9 +5032,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5066,9 +5050,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5083,9 +5067,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5102,9 +5086,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -5129,9 +5113,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5145,9 +5129,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5159,9 +5143,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5173,9 +5157,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5188,9 +5172,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5202,9 +5186,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5216,9 +5200,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -5231,9 +5215,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5244,9 +5228,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5258,9 +5242,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5272,9 +5256,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5288,9 +5272,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5306,9 +5290,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5323,9 +5307,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5342,9 +5326,9 @@ class _$FhirPatchRequestImpl extends FhirPatchRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -5448,9 +5432,9 @@ abstract class FhirPatchRequest extends FhirRequest {
   const factory FhirPatchRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -5471,17 +5455,16 @@ abstract class FhirPatchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -5530,9 +5513,9 @@ abstract class _$$FhirDeleteRequestImplCopyWith<$Res>
       {Uri base,
       Stu3ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -5555,9 +5538,9 @@ class __$$FhirDeleteRequestImplCopyWithImpl<$Res>
     Object? base = null,
     Object? type = null,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -5578,18 +5561,18 @@ class __$$FhirDeleteRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -5625,9 +5608,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -5658,20 +5641,17 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -5791,9 +5771,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5807,9 +5787,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5821,9 +5801,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5835,9 +5815,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5850,9 +5830,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5864,9 +5844,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5878,9 +5858,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -5893,9 +5873,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -5906,9 +5886,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -5920,9 +5900,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5934,9 +5914,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -5950,9 +5930,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5968,9 +5948,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -5985,9 +5965,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6004,9 +5984,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6031,9 +6011,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6047,9 +6027,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6061,9 +6041,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6075,9 +6055,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6090,9 +6070,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6104,9 +6084,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6118,9 +6098,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -6133,9 +6113,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6146,9 +6126,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -6160,9 +6140,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6174,9 +6154,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6190,9 +6170,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6208,9 +6188,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6225,9 +6205,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6244,9 +6224,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6271,9 +6251,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6287,9 +6267,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6301,9 +6281,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6315,9 +6295,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6330,9 +6310,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6344,9 +6324,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6358,9 +6338,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -6373,9 +6353,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6386,9 +6366,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -6400,9 +6380,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6414,9 +6394,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -6430,9 +6410,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6448,9 +6428,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6465,9 +6445,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -6484,9 +6464,9 @@ class _$FhirDeleteRequestImpl extends FhirDeleteRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -6591,9 +6571,9 @@ abstract class FhirDeleteRequest extends FhirRequest {
       {required final Uri base,
       required final Stu3ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -6619,17 +6599,16 @@ abstract class FhirDeleteRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -6677,9 +6656,9 @@ abstract class _$$FhirCreateRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Resource resource,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -6701,9 +6680,9 @@ class __$$FhirCreateRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? resource = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -6720,18 +6699,18 @@ class __$$FhirCreateRequestImplCopyWithImpl<$Res>
           ? _value.resource
           : resource // ignore: cast_nullable_to_non_nullable
               as Resource,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -6766,9 +6745,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
   const _$FhirCreateRequestImpl(
       {required this.base,
       required this.resource,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -6793,20 +6772,17 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -6925,9 +6901,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6941,9 +6917,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6955,9 +6931,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6969,9 +6945,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6984,9 +6960,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -6998,9 +6974,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7012,9 +6988,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7027,9 +7003,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7040,9 +7016,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7054,9 +7030,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7068,9 +7044,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7084,9 +7060,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7102,9 +7078,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7119,9 +7095,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7138,9 +7114,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7165,9 +7141,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7181,9 +7157,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7195,9 +7171,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7209,9 +7185,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7224,9 +7200,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7238,9 +7214,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7252,9 +7228,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7267,9 +7243,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7280,9 +7256,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7294,9 +7270,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7308,9 +7284,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7324,9 +7300,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7342,9 +7318,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7359,9 +7335,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7378,9 +7354,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7405,9 +7381,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7421,9 +7397,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7435,9 +7411,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7449,9 +7425,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7464,9 +7440,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7478,9 +7454,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7492,9 +7468,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -7507,9 +7483,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -7520,9 +7496,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -7534,9 +7510,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7548,9 +7524,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -7564,9 +7540,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7582,9 +7558,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7599,9 +7575,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -7618,9 +7594,9 @@ class _$FhirCreateRequestImpl extends FhirCreateRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -7724,9 +7700,9 @@ abstract class FhirCreateRequest extends FhirRequest {
   const factory FhirCreateRequest(
       {required final Uri base,
       required final Resource resource,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -7747,17 +7723,16 @@ abstract class FhirCreateRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -7805,9 +7780,9 @@ abstract class _$$FhirSearchRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Stu3ResourceType type,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       bool usePost,
@@ -7831,9 +7806,9 @@ class __$$FhirSearchRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? type = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? usePost = null,
@@ -7852,18 +7827,18 @@ class __$$FhirSearchRequestImplCopyWithImpl<$Res>
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as Stu3ResourceType,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -7906,9 +7881,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
   const _$FhirSearchRequestImpl(
       {required this.base,
       required this.type,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.usePost = false,
@@ -7937,20 +7912,17 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -8082,9 +8054,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8098,9 +8070,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8112,9 +8084,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8126,9 +8098,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8141,9 +8113,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8155,9 +8127,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8169,9 +8141,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8184,9 +8156,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8197,9 +8169,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8211,9 +8183,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8225,9 +8197,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8241,9 +8213,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8259,9 +8231,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8276,9 +8248,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8295,9 +8267,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8322,9 +8294,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8338,9 +8310,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8352,9 +8324,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8366,9 +8338,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8381,9 +8353,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8395,9 +8367,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8409,9 +8381,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8424,9 +8396,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8437,9 +8409,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8451,9 +8423,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8465,9 +8437,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8481,9 +8453,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8499,9 +8471,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8516,9 +8488,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8535,9 +8507,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8562,9 +8534,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8578,9 +8550,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8592,9 +8564,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8606,9 +8578,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8621,9 +8593,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8635,9 +8607,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8649,9 +8621,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -8664,9 +8636,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -8677,9 +8649,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -8691,9 +8663,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8705,9 +8677,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -8721,9 +8693,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8739,9 +8711,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8756,9 +8728,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -8775,9 +8747,9 @@ class _$FhirSearchRequestImpl extends FhirSearchRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -8881,9 +8853,9 @@ abstract class FhirSearchRequest extends FhirRequest {
   const factory FhirSearchRequest(
       {required final Uri base,
       required final Stu3ResourceType type,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final bool usePost,
@@ -8908,17 +8880,16 @@ abstract class FhirSearchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -8970,9 +8941,9 @@ abstract class _$$FhirSearchAllRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       MimeType? mimeType,
@@ -8993,9 +8964,9 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mimeType = freezed,
@@ -9008,18 +8979,18 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -9053,9 +9024,9 @@ class __$$FhirSearchAllRequestImplCopyWithImpl<$Res>
 class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
   const _$FhirSearchAllRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mimeType,
@@ -9078,20 +9049,17 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -9208,9 +9176,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9224,9 +9192,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9238,9 +9206,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9252,9 +9220,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9267,9 +9235,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9281,9 +9249,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9295,9 +9263,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9310,9 +9278,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9323,9 +9291,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9337,9 +9305,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9351,9 +9319,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9367,9 +9335,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9385,9 +9353,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9402,9 +9370,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9421,9 +9389,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -9448,9 +9416,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9464,9 +9432,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9478,9 +9446,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9492,9 +9460,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9507,9 +9475,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9521,9 +9489,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9535,9 +9503,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9550,9 +9518,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9563,9 +9531,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9577,9 +9545,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9591,9 +9559,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9607,9 +9575,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9625,9 +9593,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9642,9 +9610,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9661,9 +9629,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -9688,9 +9656,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9704,9 +9672,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9718,9 +9686,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9732,9 +9700,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9747,9 +9715,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9761,9 +9729,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9775,9 +9743,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -9790,9 +9758,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -9803,9 +9771,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -9817,9 +9785,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9831,9 +9799,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -9847,9 +9815,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9865,9 +9833,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9882,9 +9850,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -9901,9 +9869,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10006,9 +9974,9 @@ class _$FhirSearchAllRequestImpl extends FhirSearchAllRequest {
 abstract class FhirSearchAllRequest extends FhirRequest {
   const factory FhirSearchAllRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final MimeType? mimeType,
@@ -10028,17 +9996,16 @@ abstract class FhirSearchAllRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -10086,9 +10053,9 @@ abstract class _$$FhirCapabilitiesRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Mode mode,
@@ -10111,9 +10078,9 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? mode = null,
@@ -10127,18 +10094,18 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -10176,9 +10143,9 @@ class __$$FhirCapabilitiesRequestImplCopyWithImpl<$Res>
 class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
   const _$FhirCapabilitiesRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.mode = Mode.full,
@@ -10202,20 +10169,17 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -10338,9 +10302,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10354,9 +10318,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10368,9 +10332,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10382,9 +10346,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10397,9 +10361,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10411,9 +10375,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10425,9 +10389,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10440,9 +10404,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10453,9 +10417,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10467,9 +10431,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10481,9 +10445,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10497,9 +10461,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10515,9 +10479,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10532,9 +10496,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10551,9 +10515,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10578,9 +10542,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10594,9 +10558,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10608,9 +10572,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10622,9 +10586,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10637,9 +10601,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10651,9 +10615,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10665,9 +10629,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10680,9 +10644,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10693,9 +10657,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10707,9 +10671,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10721,9 +10685,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10737,9 +10701,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10755,9 +10719,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10772,9 +10736,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10791,9 +10755,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -10818,9 +10782,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10834,9 +10798,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10848,9 +10812,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10862,9 +10826,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10877,9 +10841,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10891,9 +10855,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10905,9 +10869,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -10920,9 +10884,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -10933,9 +10897,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -10947,9 +10911,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10961,9 +10925,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -10977,9 +10941,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -10995,9 +10959,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11012,9 +10976,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11031,9 +10995,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11136,9 +11100,9 @@ class _$FhirCapabilitiesRequestImpl extends FhirCapabilitiesRequest {
 abstract class FhirCapabilitiesRequest extends FhirRequest {
   const factory FhirCapabilitiesRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final Mode mode,
@@ -11159,17 +11123,16 @@ abstract class FhirCapabilitiesRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -11220,9 +11183,9 @@ abstract class _$$FhirTransactionRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Bundle bundle,
@@ -11230,8 +11193,6 @@ abstract class _$$FhirTransactionRequestImplCopyWith<$Res>
       String accept,
       @JsonKey(includeFromJson: false, includeToJson: false) Client? client,
       Map<String, String>? headers});
-
-  $BundleCopyWith<$Res> get bundle;
 }
 
 /// @nodoc
@@ -11247,12 +11208,12 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
-    Object? bundle = null,
+    Object? bundle = freezed,
     Object? mimeType = freezed,
     Object? accept = null,
     Object? client = freezed,
@@ -11263,18 +11224,18 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -11283,7 +11244,7 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
           ? _value._parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      bundle: null == bundle
+      bundle: freezed == bundle
           ? _value.bundle
           : bundle // ignore: cast_nullable_to_non_nullable
               as Bundle,
@@ -11305,14 +11266,6 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
               as Map<String, String>?,
     ));
   }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $BundleCopyWith<$Res> get bundle {
-    return $BundleCopyWith<$Res>(_value.bundle, (value) {
-      return _then(_value.copyWith(bundle: value));
-    });
-  }
 }
 
 /// @nodoc
@@ -11320,9 +11273,9 @@ class __$$FhirTransactionRequestImplCopyWithImpl<$Res>
 class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
   const _$FhirTransactionRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       required this.bundle,
@@ -11346,20 +11299,17 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -11443,7 +11393,7 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             const DeepCollectionEquality().equals(other._elements, _elements) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
-            (identical(other.bundle, bundle) || other.bundle == bundle) &&
+            const DeepCollectionEquality().equals(other.bundle, bundle) &&
             (identical(other.mimeType, mimeType) ||
                 other.mimeType == mimeType) &&
             (identical(other.accept, accept) || other.accept == accept) &&
@@ -11461,7 +11411,7 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
       format,
       const DeepCollectionEquality().hash(_elements),
       const DeepCollectionEquality().hash(_parameters),
-      bundle,
+      const DeepCollectionEquality().hash(bundle),
       mimeType,
       accept,
       client,
@@ -11481,9 +11431,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11497,9 +11447,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11511,9 +11461,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11525,9 +11475,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11540,9 +11490,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11554,9 +11504,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11568,9 +11518,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -11583,9 +11533,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11596,9 +11546,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -11610,9 +11560,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11624,9 +11574,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11640,9 +11590,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11658,9 +11608,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11675,9 +11625,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11694,9 +11644,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11721,9 +11671,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11737,9 +11687,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11751,9 +11701,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11765,9 +11715,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11780,9 +11730,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11794,9 +11744,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11808,9 +11758,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -11823,9 +11773,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11836,9 +11786,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -11850,9 +11800,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11864,9 +11814,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -11880,9 +11830,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11898,9 +11848,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11915,9 +11865,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -11934,9 +11884,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -11961,9 +11911,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11977,9 +11927,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -11991,9 +11941,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12005,9 +11955,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12020,9 +11970,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12034,9 +11984,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12048,9 +11998,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12063,9 +12013,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12076,9 +12026,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12090,9 +12040,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12104,9 +12054,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12120,9 +12070,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12138,9 +12088,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12155,9 +12105,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12174,9 +12124,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -12279,9 +12229,9 @@ class _$FhirTransactionRequestImpl extends FhirTransactionRequest {
 abstract class FhirTransactionRequest extends FhirRequest {
   const factory FhirTransactionRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       required final Bundle bundle,
@@ -12302,17 +12252,16 @@ abstract class FhirTransactionRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -12362,9 +12311,9 @@ abstract class _$$FhirBatchRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Bundle bundle,
@@ -12372,8 +12321,6 @@ abstract class _$$FhirBatchRequestImplCopyWith<$Res>
       String accept,
       @JsonKey(includeFromJson: false, includeToJson: false) Client? client,
       Map<String, String>? headers});
-
-  $BundleCopyWith<$Res> get bundle;
 }
 
 /// @nodoc
@@ -12388,12 +12335,12 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
-    Object? bundle = null,
+    Object? bundle = freezed,
     Object? mimeType = freezed,
     Object? accept = null,
     Object? client = freezed,
@@ -12404,18 +12351,18 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -12424,7 +12371,7 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
           ? _value._parameters
           : parameters // ignore: cast_nullable_to_non_nullable
               as List<String>,
-      bundle: null == bundle
+      bundle: freezed == bundle
           ? _value.bundle
           : bundle // ignore: cast_nullable_to_non_nullable
               as Bundle,
@@ -12446,14 +12393,6 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
               as Map<String, String>?,
     ));
   }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $BundleCopyWith<$Res> get bundle {
-    return $BundleCopyWith<$Res>(_value.bundle, (value) {
-      return _then(_value.copyWith(bundle: value));
-    });
-  }
 }
 
 /// @nodoc
@@ -12461,9 +12400,9 @@ class __$$FhirBatchRequestImplCopyWithImpl<$Res>
 class _$FhirBatchRequestImpl extends FhirBatchRequest {
   const _$FhirBatchRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       required this.bundle,
@@ -12487,20 +12426,17 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -12584,7 +12520,7 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             const DeepCollectionEquality().equals(other._elements, _elements) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
-            (identical(other.bundle, bundle) || other.bundle == bundle) &&
+            const DeepCollectionEquality().equals(other.bundle, bundle) &&
             (identical(other.mimeType, mimeType) ||
                 other.mimeType == mimeType) &&
             (identical(other.accept, accept) || other.accept == accept) &&
@@ -12602,7 +12538,7 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
       format,
       const DeepCollectionEquality().hash(_elements),
       const DeepCollectionEquality().hash(_parameters),
-      bundle,
+      const DeepCollectionEquality().hash(bundle),
       mimeType,
       accept,
       client,
@@ -12622,9 +12558,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12638,9 +12574,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12652,9 +12588,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12666,9 +12602,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12681,9 +12617,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12695,9 +12631,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12709,9 +12645,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12724,9 +12660,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12737,9 +12673,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12751,9 +12687,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12765,9 +12701,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -12781,9 +12717,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12799,9 +12735,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12816,9 +12752,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -12835,9 +12771,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -12862,9 +12798,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12878,9 +12814,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12892,9 +12828,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12906,9 +12842,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12921,9 +12857,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12935,9 +12871,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12949,9 +12885,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -12964,9 +12900,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -12977,9 +12913,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -12991,9 +12927,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13005,9 +12941,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13021,9 +12957,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13039,9 +12975,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13056,9 +12992,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13075,9 +13011,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -13102,9 +13038,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13118,9 +13054,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13132,9 +13068,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13146,9 +13082,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13161,9 +13097,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13175,9 +13111,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13189,9 +13125,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -13204,9 +13140,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13217,9 +13153,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -13231,9 +13167,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13245,9 +13181,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13261,9 +13197,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13279,9 +13215,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13296,9 +13232,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -13315,9 +13251,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -13420,9 +13356,9 @@ class _$FhirBatchRequestImpl extends FhirBatchRequest {
 abstract class FhirBatchRequest extends FhirRequest {
   const factory FhirBatchRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       required final Bundle bundle,
@@ -13443,17 +13379,16 @@ abstract class FhirBatchRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -13505,9 +13440,9 @@ abstract class _$$FhirHistoryRequestImplCopyWith<$Res>
       {Uri base,
       Stu3ResourceType type,
       String fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -13534,9 +13469,9 @@ class __$$FhirHistoryRequestImplCopyWithImpl<$Res>
     Object? base = null,
     Object? type = null,
     Object? fhirId = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -13561,18 +13496,18 @@ class __$$FhirHistoryRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -13624,9 +13559,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
       {required this.base,
       required this.type,
       required this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -13661,20 +13596,17 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -13824,9 +13756,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13840,9 +13772,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13854,9 +13786,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13868,9 +13800,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13883,9 +13815,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13897,9 +13829,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13911,9 +13843,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -13926,9 +13858,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -13939,9 +13871,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -13953,9 +13885,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13967,9 +13899,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -13983,9 +13915,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14001,9 +13933,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14018,9 +13950,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14037,9 +13969,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14079,9 +14011,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14095,9 +14027,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14109,9 +14041,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14123,9 +14055,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14138,9 +14070,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14152,9 +14084,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14166,9 +14098,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -14181,9 +14113,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14194,9 +14126,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -14208,9 +14140,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14222,9 +14154,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14238,9 +14170,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14256,9 +14188,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14273,9 +14205,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14292,9 +14224,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14334,9 +14266,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14350,9 +14282,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14364,9 +14296,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14378,9 +14310,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14393,9 +14325,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14407,9 +14339,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14421,9 +14353,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -14436,9 +14368,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -14449,9 +14381,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -14463,9 +14395,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14477,9 +14409,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -14493,9 +14425,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14511,9 +14443,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14528,9 +14460,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -14547,9 +14479,9 @@ class _$FhirHistoryRequestImpl extends FhirHistoryRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -14669,9 +14601,9 @@ abstract class FhirHistoryRequest extends FhirRequest {
       {required final Uri base,
       required final Stu3ResourceType type,
       required final String fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -14701,17 +14633,16 @@ abstract class FhirHistoryRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -14777,9 +14708,9 @@ abstract class _$$FhirHistoryTypeRequestImplCopyWith<$Res>
   $Res call(
       {Uri base,
       Stu3ResourceType type,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -14806,9 +14737,9 @@ class __$$FhirHistoryTypeRequestImplCopyWithImpl<$Res>
   $Res call({
     Object? base = null,
     Object? type = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -14829,18 +14760,18 @@ class __$$FhirHistoryTypeRequestImplCopyWithImpl<$Res>
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as Stu3ResourceType,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -14891,9 +14822,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
   const _$FhirHistoryTypeRequestImpl(
       {required this.base,
       required this.type,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -14924,20 +14855,17 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -15085,9 +15013,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15101,9 +15029,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15115,9 +15043,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15129,9 +15057,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15144,9 +15072,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15158,9 +15086,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15172,9 +15100,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15187,9 +15115,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15200,9 +15128,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15214,9 +15142,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15228,9 +15156,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15244,9 +15172,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15262,9 +15190,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15279,9 +15207,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15298,9 +15226,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15339,9 +15267,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15355,9 +15283,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15369,9 +15297,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15383,9 +15311,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15398,9 +15326,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15412,9 +15340,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15426,9 +15354,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15441,9 +15369,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15454,9 +15382,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15468,9 +15396,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15482,9 +15410,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15498,9 +15426,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15516,9 +15444,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15533,9 +15461,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15552,9 +15480,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15593,9 +15521,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15609,9 +15537,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15623,9 +15551,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15637,9 +15565,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15652,9 +15580,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15666,9 +15594,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15680,9 +15608,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -15695,9 +15623,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -15708,9 +15636,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -15722,9 +15650,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15736,9 +15664,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -15752,9 +15680,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15770,9 +15698,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15787,9 +15715,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -15806,9 +15734,9 @@ class _$FhirHistoryTypeRequestImpl extends FhirHistoryTypeRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -15926,9 +15854,9 @@ abstract class FhirHistoryTypeRequest extends FhirRequest {
   const factory FhirHistoryTypeRequest(
       {required final Uri base,
       required final Stu3ResourceType type,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -15955,17 +15883,16 @@ abstract class FhirHistoryTypeRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -16030,9 +15957,9 @@ abstract class _$$FhirHistoryAllRequestImplCopyWith<$Res>
   @useResult
   $Res call(
       {Uri base,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       int? count,
@@ -16057,9 +15984,9 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? base = null,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? count = freezed,
@@ -16076,18 +16003,18 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
           ? _value.base
           : base // ignore: cast_nullable_to_non_nullable
               as Uri,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -16137,9 +16064,9 @@ class __$$FhirHistoryAllRequestImplCopyWithImpl<$Res>
 class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
   const _$FhirHistoryAllRequestImpl(
       {required this.base,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.count,
@@ -16166,20 +16093,17 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -16325,9 +16249,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16341,9 +16265,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16355,9 +16279,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16369,9 +16293,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16384,9 +16308,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16398,9 +16322,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16412,9 +16336,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16427,9 +16351,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16440,9 +16364,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16454,9 +16378,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16468,9 +16392,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16484,9 +16408,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16502,9 +16426,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16519,9 +16443,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16538,9 +16462,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -16565,9 +16489,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16581,9 +16505,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16595,9 +16519,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16609,9 +16533,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16624,9 +16548,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16638,9 +16562,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16652,9 +16576,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16667,9 +16591,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16680,9 +16604,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16694,9 +16618,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16708,9 +16632,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16724,9 +16648,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16742,9 +16666,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16759,9 +16683,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16778,9 +16702,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -16805,9 +16729,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16821,9 +16745,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16835,9 +16759,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16849,9 +16773,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16864,9 +16788,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16878,9 +16802,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16892,9 +16816,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -16907,9 +16831,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -16920,9 +16844,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -16934,9 +16858,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16948,9 +16872,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -16964,9 +16888,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16982,9 +16906,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -16999,9 +16923,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17018,9 +16942,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -17123,9 +17047,9 @@ class _$FhirHistoryAllRequestImpl extends FhirHistoryAllRequest {
 abstract class FhirHistoryAllRequest extends FhirRequest {
   const factory FhirHistoryAllRequest(
       {required final Uri base,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final int? count,
@@ -17149,17 +17073,16 @@ abstract class FhirHistoryAllRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in
@@ -17225,9 +17148,9 @@ abstract class _$$FhirOperationRequestImplCopyWith<$Res>
       {Uri base,
       Stu3ResourceType? type,
       String? fhirId,
-      bool pretty,
+      bool? pretty,
       Summary summary,
-      String format,
+      String? format,
       List<String> elements,
       List<String> parameters,
       Parameters? fhirParameter,
@@ -17238,8 +17161,6 @@ abstract class _$$FhirOperationRequestImplCopyWith<$Res>
       String accept,
       @JsonKey(includeFromJson: false, includeToJson: false) Client? client,
       Map<String, String>? headers});
-
-  $ParametersCopyWith<$Res>? get fhirParameter;
 }
 
 /// @nodoc
@@ -17256,9 +17177,9 @@ class __$$FhirOperationRequestImplCopyWithImpl<$Res>
     Object? base = null,
     Object? type = freezed,
     Object? fhirId = freezed,
-    Object? pretty = null,
+    Object? pretty = freezed,
     Object? summary = null,
-    Object? format = null,
+    Object? format = freezed,
     Object? elements = null,
     Object? parameters = null,
     Object? fhirParameter = freezed,
@@ -17283,18 +17204,18 @@ class __$$FhirOperationRequestImplCopyWithImpl<$Res>
           ? _value.fhirId
           : fhirId // ignore: cast_nullable_to_non_nullable
               as String?,
-      pretty: null == pretty
+      pretty: freezed == pretty
           ? _value.pretty
           : pretty // ignore: cast_nullable_to_non_nullable
-              as bool,
+              as bool?,
       summary: null == summary
           ? _value.summary
           : summary // ignore: cast_nullable_to_non_nullable
               as Summary,
-      format: null == format
+      format: freezed == format
           ? _value.format
           : format // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
       elements: null == elements
           ? _value._elements
           : elements // ignore: cast_nullable_to_non_nullable
@@ -17337,18 +17258,6 @@ class __$$FhirOperationRequestImplCopyWithImpl<$Res>
               as Map<String, String>?,
     ));
   }
-
-  @override
-  @pragma('vm:prefer-inline')
-  $ParametersCopyWith<$Res>? get fhirParameter {
-    if (_value.fhirParameter == null) {
-      return null;
-    }
-
-    return $ParametersCopyWith<$Res>(_value.fhirParameter!, (value) {
-      return _then(_value.copyWith(fhirParameter: value));
-    });
-  }
 }
 
 /// @nodoc
@@ -17358,9 +17267,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
       {required this.base,
       this.type,
       this.fhirId,
-      this.pretty = false,
+      this.pretty,
       this.summary = Summary.none,
-      this.format = 'json',
+      this.format,
       final List<String> elements = const <String>[],
       final List<String> parameters = const <String>[],
       this.fhirParameter,
@@ -17391,20 +17300,17 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
 
   /// [pretty] - pretty print the json formatting in the response
   @override
-  @JsonKey()
-  final bool pretty;
+  final bool? pretty;
 
   /// [summary] - do you want the result to be a summary
   @override
   @JsonKey()
   final Summary summary;
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
   @override
-  @JsonKey()
-  final String format;
+  final String? format;
 
   /// [elements] - elements you need to pass in
   final List<String> _elements;
@@ -17501,8 +17407,8 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             const DeepCollectionEquality().equals(other._elements, _elements) &&
             const DeepCollectionEquality()
                 .equals(other._parameters, _parameters) &&
-            (identical(other.fhirParameter, fhirParameter) ||
-                other.fhirParameter == fhirParameter) &&
+            const DeepCollectionEquality()
+                .equals(other.fhirParameter, fhirParameter) &&
             (identical(other.operation, operation) ||
                 other.operation == operation) &&
             (identical(other.usePost, usePost) || other.usePost == usePost) &&
@@ -17527,7 +17433,7 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
       format,
       const DeepCollectionEquality().hash(_elements),
       const DeepCollectionEquality().hash(_parameters),
-      fhirParameter,
+      const DeepCollectionEquality().hash(fhirParameter),
       operation,
       usePost,
       useFormData,
@@ -17551,9 +17457,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17567,9 +17473,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17581,9 +17487,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17595,9 +17501,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17610,9 +17516,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17624,9 +17530,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17638,9 +17544,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -17653,9 +17559,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17666,9 +17572,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -17680,9 +17586,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17694,9 +17600,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17710,9 +17616,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17728,9 +17634,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     required TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17745,9 +17651,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     required TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17764,9 +17670,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -17806,9 +17712,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17822,9 +17728,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17836,9 +17742,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17850,9 +17756,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17865,9 +17771,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17879,9 +17785,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17893,9 +17799,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -17908,9 +17814,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -17921,9 +17827,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -17935,9 +17841,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17949,9 +17855,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -17965,9 +17871,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -17983,9 +17889,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult? Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18000,9 +17906,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     TResult? Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18019,9 +17925,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -18061,9 +17967,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18077,9 +17983,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Stu3ResourceType type,
             String fhirId,
             FhirId vid,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18091,9 +17997,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18105,9 +18011,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18120,9 +18026,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18134,9 +18040,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Resource resource,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18148,9 +18054,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             bool usePost,
@@ -18163,9 +18069,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         search,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             MimeType? mimeType,
@@ -18176,9 +18082,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         searchAll,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Mode mode,
@@ -18190,9 +18096,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         capabilities,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -18204,9 +18110,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         transaction,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Bundle bundle,
@@ -18220,9 +18126,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType type,
             String fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18238,9 +18144,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
     TResult Function(
             Uri base,
             Stu3ResourceType type,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18255,9 +18161,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
         historyType,
     TResult Function(
             Uri base,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             int? count,
@@ -18274,9 +18180,9 @@ class _$FhirOperationRequestImpl extends FhirOperationRequest {
             Uri base,
             Stu3ResourceType? type,
             String? fhirId,
-            bool pretty,
+            bool? pretty,
             Summary summary,
-            String format,
+            String? format,
             List<String> elements,
             List<String> parameters,
             Parameters? fhirParameter,
@@ -18396,9 +18302,9 @@ abstract class FhirOperationRequest extends FhirRequest {
       {required final Uri base,
       final Stu3ResourceType? type,
       final String? fhirId,
-      final bool pretty,
+      final bool? pretty,
       final Summary summary,
-      final String format,
+      final String? format,
       final List<String> elements,
       final List<String> parameters,
       final Parameters? fhirParameter,
@@ -18424,17 +18330,16 @@ abstract class FhirOperationRequest extends FhirRequest {
   @override
 
   /// [pretty] - pretty print the json formatting in the response
-  bool get pretty;
+  bool? get pretty;
   @override
 
   /// [summary] - do you want the result to be a summary
   Summary get summary;
   @override
 
-  /// [format] - currently requests json, but could consider requesting
-  ///   json+fhir or fhir+json (would not request XML as this library doesn't
-  ///   work with XML)
-  String get format;
+  /// [format] - Possible formats are: json, json+fhir or fhir+json
+  /// (would not request XML as this library doesn't work with XML)
+  String? get format;
   @override
 
   /// [elements] - elements you need to pass in

--- a/lib/stu3/fhir_request.g.dart
+++ b/lib/stu3/fhir_request.g.dart
@@ -12,10 +12,10 @@ _$FhirReadRequestImpl _$$FhirReadRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$Stu3ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -201,10 +201,10 @@ _$FhirVReadRequestImpl _$$FhirVReadRequestImplFromJson(
       type: $enumDecode(_$Stu3ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
       vid: FhirId.fromJson(json['vid']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -253,10 +253,10 @@ _$FhirUpdateRequestImpl _$$FhirUpdateRequestImplFromJson(
     _$FhirUpdateRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -303,10 +303,10 @@ _$FhirPatchRequestImpl _$$FhirPatchRequestImplFromJson(
     _$FhirPatchRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -354,10 +354,10 @@ _$FhirDeleteRequestImpl _$$FhirDeleteRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$Stu3ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -405,10 +405,10 @@ _$FhirCreateRequestImpl _$$FhirCreateRequestImplFromJson(
     _$FhirCreateRequestImpl(
       base: Uri.parse(json['base'] as String),
       resource: Resource.fromJson(json['resource'] as Map<String, dynamic>),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -455,10 +455,10 @@ _$FhirSearchRequestImpl _$$FhirSearchRequestImplFromJson(
     _$FhirSearchRequestImpl(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$Stu3ResourceTypeEnumMap, json['type']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -518,10 +518,10 @@ _$FhirSearchAllRequestImpl _$$FhirSearchAllRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirSearchAllRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -566,10 +566,10 @@ _$FhirCapabilitiesRequestImpl _$$FhirCapabilitiesRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirCapabilitiesRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -622,10 +622,10 @@ _$FhirTransactionRequestImpl _$$FhirTransactionRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirTransactionRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -672,10 +672,10 @@ _$FhirBatchRequestImpl _$$FhirBatchRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirBatchRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -724,10 +724,10 @@ _$FhirHistoryRequestImpl _$$FhirHistoryRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$Stu3ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -787,10 +787,10 @@ _$FhirHistoryTypeRequestImpl _$$FhirHistoryTypeRequestImplFromJson(
     _$FhirHistoryTypeRequestImpl(
       base: Uri.parse(json['base'] as String),
       type: $enumDecode(_$Stu3ResourceTypeEnumMap, json['type']),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -848,10 +848,10 @@ _$FhirHistoryAllRequestImpl _$$FhirHistoryAllRequestImplFromJson(
         Map<String, dynamic> json) =>
     _$FhirHistoryAllRequestImpl(
       base: Uri.parse(json['base'] as String),
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??
@@ -910,10 +910,10 @@ _$FhirOperationRequestImpl _$$FhirOperationRequestImplFromJson(
       base: Uri.parse(json['base'] as String),
       type: $enumDecodeNullable(_$Stu3ResourceTypeEnumMap, json['type']),
       fhirId: json['fhirId'] as String?,
-      pretty: json['pretty'] as bool? ?? false,
+      pretty: json['pretty'] as bool?,
       summary: $enumDecodeNullable(_$SummaryEnumMap, json['summary']) ??
           Summary.none,
-      format: json['format'] as String? ?? 'json',
+      format: json['format'] as String?,
       elements: (json['elements'] as List<dynamic>?)
               ?.map((e) => e as String)
               .toList() ??

--- a/test/fhir_at_rest_test.dart
+++ b/test/fhir_at_rest_test.dart
@@ -11,7 +11,7 @@ Future<void> main() async {
   r4_uri_test.fhirUriTest();
   r4_requests_test.requestsTest();
   r4_http_request_tests.httpRequestTests();
-  
+
   r5_uri_test.fhirUriTest();
   r5_requests_test.requestsTest();
   r5_http_request_tests.httpRequestTests();

--- a/test/r4/fhir_uri_test.dart
+++ b/test/r4/fhir_uri_test.dart
@@ -12,6 +12,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -27,6 +29,7 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         pretty: true,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -43,6 +46,7 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         pretty: true,
         summary: Summary.true_,
       );
@@ -60,6 +64,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         summary: Summary.count,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -76,6 +82,7 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '1227442',
+        format: mimeType,
         pretty: true,
         elements: <String>['name'],
       );
@@ -94,6 +101,7 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '1227442',
+        format: mimeType,
         pretty: true,
         elements: <String>['name', 'gender'],
       );
@@ -113,6 +121,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         vid: FhirId('6789'),
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -129,6 +139,7 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         vid: FhirId('6789'),
         pretty: true,
       );
@@ -147,6 +158,7 @@ Future<void> fhirUriTest() async {
         type: R4ResourceType.Patient,
         fhirId: '12345',
         vid: FhirId('6789'),
+        format: mimeType,
         pretty: true,
         summary: Summary.true_,
       );
@@ -164,6 +176,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         vid: FhirId('6789'),
         summary: Summary.count,
       );
@@ -183,6 +197,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.transaction(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         bundle: bundle,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -200,6 +216,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -214,6 +232,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.historyType(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -227,6 +247,8 @@ Future<void> fhirUriTest() async {
     test('history for everything', () async {
       final FhirRequest request = FhirRequest.historyAll(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -247,6 +269,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         parameters: parameters,
       );
 
@@ -267,6 +291,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.update(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -284,6 +310,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.patch(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -301,6 +329,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -318,6 +348,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.create(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -334,6 +366,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.capabilities(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         mode: Mode.normative,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -356,6 +390,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         operation: 'everything',
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -376,6 +412,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '744742',
+        format: mimeType,
+        pretty: false,
         operation: 'everything',
         parameters: parameters,
       );
@@ -397,6 +435,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
+        format: mimeType,
+        pretty: false,
         parameters: <String>['_id=12345'],
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -412,6 +452,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
+        format: mimeType,
+        pretty: false,
         restfulRequest: RestfulRequest.post_,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -428,6 +470,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.search(
           base: Uri.parse('http://hapi.fhir.org/baseR4'),
           type: R4ResourceType.Observation,
+          format: mimeType,
+          pretty: false,
           parameters: parameters);
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -446,6 +490,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Condition,
+        format: mimeType,
+        pretty: false,
         parameters: parameters,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -466,6 +512,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.DiagnosticReport,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -483,6 +531,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -500,6 +550,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -517,6 +569,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -534,6 +588,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -550,6 +606,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.RiskAssessment,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -569,6 +627,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -590,6 +650,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -611,6 +673,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.searchAll(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -630,6 +694,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -647,6 +713,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Composition,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -666,6 +734,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Condition,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -685,6 +755,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -704,6 +776,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -723,6 +797,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -742,6 +818,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -759,6 +837,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,

--- a/test/r4/http_request_tests.dart
+++ b/test/r4/http_request_tests.dart
@@ -5,13 +5,15 @@ import 'package:fhir/r4.dart';
 import 'package:fhir_at_rest/r4.dart';
 import 'package:test/test.dart';
 
-void httpRequestTests()  {
+void httpRequestTests() {
   group('FhirRequest - READ:', () {
-    test('get patient', ()  {
+    test('get patient', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -27,11 +29,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient with pretty', ()  {
+    test('get patient with pretty', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
         pretty: true,
       );
       final FhirHttpRequest fhirHttpRequest = request
@@ -49,11 +52,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient with pretty and summary true', ()  {
+    test('get patient with pretty and summary true', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
         pretty: true,
         summary: Summary.true_,
       );
@@ -72,11 +76,13 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient with summary count', ()  {
+    test('get patient with summary count', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
         summary: Summary.count,
       );
       final FhirHttpRequest fhirHttpRequest = request
@@ -94,11 +100,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient  with pretty, only want to return name', ()  {
+    test('get patient  with pretty, only want to return name', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '1227442',
+        format: 'json',
         pretty: true,
         elements: <String>['name'],
       );
@@ -117,12 +124,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient with pretty, only want to return name and gender',
-        ()  {
+    test('get patient with pretty, only want to return name and gender', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '1227442',
+        format: 'json',
         pretty: true,
         elements: <String>['name', 'gender'],
       );
@@ -143,11 +150,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'read']);
 
   group('FhirRequest - VREAD:', () {
-    test('get patient version', ()  {
+    test('get patient version', () {
       final FhirRequest request = FhirRequest.vRead(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
         vid: FhirId('6789'),
       );
       final FhirHttpRequest fhirHttpRequest = request
@@ -165,11 +174,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient version with pretty', ()  {
+    test('get patient version with pretty', () {
       final FhirRequest request = FhirRequest.vRead(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
         vid: FhirId('6789'),
         pretty: true,
       );
@@ -188,11 +198,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient version with pretty and summary true', ()  {
+    test('get patient version with pretty and summary true', () {
       final FhirRequest request = FhirRequest.vRead(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
         vid: FhirId('6789'),
         pretty: true,
         summary: Summary.true_,
@@ -212,11 +223,13 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient version with summary count', ()  {
+    test('get patient version with summary count', () {
       final FhirRequest request = FhirRequest.vRead(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
         vid: FhirId('6789'),
         summary: Summary.count,
       );
@@ -237,7 +250,7 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'vread']);
 
   group('FhirRequest - TRANSACTION:', () {
-    test('transaction/batch', ()  {
+    test('transaction/batch', () {
       final Bundle bundle = Bundle(
           type: FhirCode('transaction'),
           fhirId: '12345',
@@ -250,6 +263,8 @@ void httpRequestTests()  {
       final FhirRequest request = FhirRequest.transaction(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         bundle: bundle,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -267,7 +282,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('batch with error in bundle', ()  {
+    test('batch with error in bundle', () {
       final Bundle bundle = Bundle(
           type: FhirCode('batch'),
           fhirId: '12345',
@@ -275,6 +290,8 @@ void httpRequestTests()  {
       final FhirRequest request = FhirRequest.batch(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         bundle: bundle,
+        format: 'json',
+        pretty: false,
       );
       try {
         request.toFhirHttpRequest(headers: <String, String>{'test': 'header'});
@@ -288,11 +305,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'transaction']);
 
   group('FhirRequest - HISTORY:', () {
-    test('observation history by type and id', ()  {
+    test('observation history by type and id', () {
       final FhirRequest request = FhirRequest.history(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -309,10 +328,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation history by type', ()  {
+    test('observation history by type', () {
       final FhirRequest request = FhirRequest.historyType(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -329,9 +350,11 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('history for everything', ()  {
+    test('history for everything', () {
       final FhirRequest request = FhirRequest.historyAll(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -349,7 +372,7 @@ void httpRequestTests()  {
     });
 
     test('history resource by type and id, count of 10, after a specified date',
-        ()  {
+        () {
       final List<String> parameters = <String>[
         '_count=10',
         '_since=2020-10-08T16:58:07.241117Z',
@@ -358,6 +381,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
         parameters: parameters,
       );
 
@@ -378,10 +403,12 @@ void httpRequestTests()  {
 
     test(
         'search all history, count = 10, since 2020-10-08, and only '
-        'those that are included in the List/12345', ()  {
+        'those that are included in the List/12345', () {
       final FhirRequest request = FhirRequest.historyAll(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         reference: 'List/12345',
+        format: 'json',
+        pretty: false,
         parameters: <String>['_count=10', '_since=2020-10-08'],
       );
       final FhirHttpRequest fhirHttpRequest = request
@@ -401,11 +428,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'history']);
 
   group('FhirRequest - UPDATE:', () {
-    test('update patient by id', ()  {
+    test('update patient by id', () {
       const Patient patient = Patient(fhirId: '12345');
       final FhirRequest request = FhirRequest.update(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         resource: patient,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -426,11 +455,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'update']);
 
   group('FhirRequest - PATCH:', () {
-    test('patch patient by id', ()  {
+    test('patch patient by id', () {
       const Patient patient = Patient(fhirId: '12345');
       final FhirRequest request = FhirRequest.patch(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         resource: patient,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -451,11 +482,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'patch']);
 
   group('FhirRequest - DELETE:', () {
-    test('delete patient', ()  {
+    test('delete patient', () {
       final FhirRequest request = FhirRequest.delete(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -474,11 +507,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'delete']);
 
   group('FhirRequest - CREATE:', () {
-    test('create patient', ()  {
+    test('create patient', () {
       const Patient patient = Patient(fhirId: '12345');
       final FhirRequest request = FhirRequest.create(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         resource: patient,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -498,10 +533,12 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'create']);
 
   group('FhirRequest - CAPABILITIES:', () {
-    test('capabilities with mode normative', ()  {
+    test('capabilities with mode normative', () {
       final FhirRequest request = FhirRequest.capabilities(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         mode: Mode.normative,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -520,7 +557,7 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'capabilities']);
 
   group('FhirRequest - OPERATION:', () {
-    test(r'$everything operation', ()  {
+    test(r'$everything operation', () {
       final List<String> parameters = <String>[
         'start=2020-01-01',
         'end=2020-08-01'
@@ -529,6 +566,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         operation: 'everything',
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -545,7 +584,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test(r'$everything operation for Patient 744742', ()  {
+    test(r'$everything operation for Patient 744742', () {
       final List<String> parameters = <String>[
         'start=2020-01-01',
         'end=2020-08-01'
@@ -556,6 +595,8 @@ void httpRequestTests()  {
         fhirId: '744742',
         operation: 'everything',
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
 
       final FhirHttpRequest fhirHttpRequest = request
@@ -575,12 +616,14 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'operation']);
 
   group('FhirRequest - SEARCH:', () {
-    test('patient id search', ()  {
+    test('patient id search', () {
       final List<String> parameters = <String>['_id=12345'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -597,11 +640,13 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient id search using post', ()  {
+    test('patient id search using post', () {
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         restfulRequest: RestfulRequest.post_,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -618,12 +663,15 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation time search', ()  {
+    test('observation time search', () {
       final List<String> parameters = <String>['_lastUpdated=gt2010-10-01'];
       final FhirRequest request = FhirRequest.search(
-          base: Uri.parse('http://hapi.fhir.org/baseR4'),
-          type: R4ResourceType.Observation,
-          parameters: parameters);
+        base: Uri.parse('http://hapi.fhir.org/baseR4'),
+        type: R4ResourceType.Observation,
+        parameters: parameters,
+        format: 'json',
+        pretty: false,
+      );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
 
@@ -639,7 +687,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('condition search, code parameter (_tag)', ()  {
+    test('condition search, code parameter (_tag)', () {
       final List<String> parameters = <String>[
         '_tag=http://acme.org/codes|needs-review'
       ];
@@ -647,6 +695,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Condition,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -663,7 +713,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('diagnostic report rearch, uri parameter (_profile)', ()  {
+    test('diagnostic report rearch, uri parameter (_profile)', () {
       final List<String> parameters = <String>[
         '_profile=http://acme.org/codes'
       ];
@@ -671,6 +721,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.DiagnosticReport,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -687,12 +739,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search if gender present', ()  {
+    test('patient search if gender present', () {
       final List<String> parameters = <String>['gender:missing=true'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -709,12 +763,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search if gender present', ()  {
+    test('patient search if gender present', () {
       final List<String> parameters = <String>['gender:missing=false'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -731,12 +787,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search for exact text match', ()  {
+    test('patient search for exact text match', () {
       final List<String> parameters = <String>['_text:exact=Stark'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -753,12 +811,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation search "le"', ()  {
+    test('observation search "le"', () {
       final List<String> parameters = <String>['_lastUpdated=le2010-10-01'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -775,12 +835,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('risk assessment search, probability > 0.8', ()  {
+    test('risk assessment search, probability > 0.8', () {
       final List<String> parameters = <String>['probability=gt0.8'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.RiskAssessment,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -797,7 +859,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search for birthday between two dates', ()  {
+    test('patient search for birthday between two dates', () {
       final List<String> parameters = <String>[
         'birthdate=ge2010-01-01',
         'birthdate=le2011-12-31',
@@ -806,6 +868,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -822,7 +886,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search given name with parameters', ()  {
+    test('patient search given name with parameters', () {
       final List<String> parameters = <String>[
         'given=eve',
         'given:contains=eve',
@@ -832,6 +896,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -848,7 +914,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search given name with parameters', ()  {
+    test('patient search given name with parameters', () {
       final List<String> parameters = <String>[
         '_type=Patient',
         'given=eve',
@@ -858,6 +924,8 @@ void httpRequestTests()  {
       final FhirRequest request = FhirRequest.searchAll(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -874,7 +942,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search with identifier', ()  {
+    test('patient search with identifier', () {
       final List<String> parameters = <String>[
         'identifier=http://acme.org/patient|2345'
       ];
@@ -882,6 +950,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -898,12 +968,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('composition search section code', ()  {
+    test('composition search section code', () {
       final List<String> parameters = <String>['section:not=48765-2'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Composition,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -920,7 +992,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('condition search via snomed code', ()  {
+    test('condition search via snomed code', () {
       final List<String> parameters = <String>[
         'code:in=http://snomed.info/sct?fhir_vs=isa/126851005'
       ];
@@ -928,6 +1000,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Condition,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -944,7 +1018,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search by mr code', ()  {
+    test('patient search by mr code', () {
       final List<String> parameters = <String>[
         'identifier:of-type=http://terminology.hl7.org/CodeSystem/v2-0203|MR|446053'
       ];
@@ -952,6 +1026,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -968,7 +1044,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation search by quantity, with prefix', ()  {
+    test('observation search by quantity, with prefix', () {
       final List<String> parameters = <String>[
         'value-quantity=ap5.4|http://unitsofmeasure.org|mg'
       ];
@@ -976,6 +1052,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -992,7 +1070,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation search by quantity, without prefix', ()  {
+    test('observation search by quantity, without prefix', () {
       final List<String> parameters = <String>[
         'value-quantity=5.4|http://unitsofmeasure.org|mg'
       ];
@@ -1000,6 +1078,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -1016,7 +1096,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation search by quantity, testing number parsing', ()  {
+    test('observation search by quantity, testing number parsing', () {
       final List<String> parameters = <String>[
         'value-quantity=0.0054|http://unitsofmeasure.org|g'
       ];
@@ -1024,6 +1104,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -1040,12 +1122,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation search by reference, using url', ()  {
+    test('observation search by reference, using url', () {
       final List<String> parameters = <String>['subject=Patient/123'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});

--- a/test/r4/requests_test.dart
+++ b/test/r4/requests_test.dart
@@ -16,6 +16,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -34,6 +36,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         pretty: true,
       );
       final OperationOutcome? response =
@@ -53,6 +56,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         pretty: true,
         summary: Summary.true_,
       );
@@ -73,6 +77,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         summary: Summary.count,
       );
       final OperationOutcome? response =
@@ -92,6 +98,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '1227442',
+        format: mimeType,
         pretty: true,
         elements: <String>['name'],
       );
@@ -113,6 +120,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '1227442',
+        format: mimeType,
         pretty: true,
         elements: <String>['name', 'gender'],
       );
@@ -135,6 +143,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         vid: FhirId('6789'),
       );
       final OperationOutcome? response =
@@ -154,6 +164,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         vid: FhirId('6789'),
         pretty: true,
       );
@@ -174,6 +185,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         vid: FhirId('6789'),
         pretty: true,
         summary: Summary.true_,
@@ -195,6 +207,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         vid: FhirId('6789'),
         summary: Summary.count,
       );
@@ -225,6 +239,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.transaction(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         bundle: bundle,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -246,6 +262,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.batch(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         bundle: bundle,
+        format: mimeType,
+        pretty: false,
       );
       try {
         final OperationOutcome? response =
@@ -270,6 +288,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -287,6 +307,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.historyType(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -303,6 +325,8 @@ Future<void> requestsTest() async {
     test('history for everything', () async {
       final FhirRequest request = FhirRequest.historyAll(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -327,6 +351,8 @@ Future<void> requestsTest() async {
         type: R4ResourceType.Observation,
         fhirId: '12345',
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
 
       final OperationOutcome? response =
@@ -349,6 +375,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         reference: 'List/12345',
         parameters: <String>['_count=10', '_since=2020-10-08'],
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -370,6 +398,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.update(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -390,6 +420,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.patch(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -410,6 +442,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -430,6 +464,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.create(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -449,6 +485,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.capabilities(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         mode: Mode.normative,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -474,6 +512,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         operation: 'everything',
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -499,6 +539,8 @@ Future<void> requestsTest() async {
         fhirId: '744742',
         operation: 'everything',
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
 
       final OperationOutcome? response =
@@ -522,6 +564,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -540,6 +584,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         restfulRequest: RestfulRequest.post_,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -558,6 +604,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.search(
           base: Uri.parse('http://hapi.fhir.org/baseR4'),
           type: R4ResourceType.Observation,
+          format: mimeType,
+          pretty: false,
           parameters: parameters);
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -580,6 +628,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Condition,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -602,6 +652,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.DiagnosticReport,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -622,6 +674,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -642,6 +696,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -662,6 +718,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -682,6 +740,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -701,6 +761,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.RiskAssessment,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -723,6 +785,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -747,6 +811,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -771,6 +837,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.searchAll(
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -793,6 +861,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -813,6 +883,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Composition,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -835,6 +907,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Condition,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -857,6 +931,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -879,6 +955,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -901,6 +979,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -923,6 +1003,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -943,6 +1025,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR4'),
         type: R4ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})

--- a/test/r5/fhir_uri_test.dart
+++ b/test/r5/fhir_uri_test.dart
@@ -12,6 +12,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -27,6 +29,7 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         pretty: true,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -43,6 +46,7 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         pretty: true,
         summary: Summary.true_,
       );
@@ -60,6 +64,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         summary: Summary.count,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -76,6 +82,7 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '1227442',
+        format: mimeType,
         pretty: true,
         elements: <String>['name'],
       );
@@ -94,6 +101,7 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '1227442',
+        format: mimeType,
         pretty: true,
         elements: <String>['name', 'gender'],
       );
@@ -113,6 +121,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         vid: FhirId('6789'),
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -129,6 +139,7 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         vid: FhirId('6789'),
         pretty: true,
       );
@@ -147,6 +158,7 @@ Future<void> fhirUriTest() async {
         type: R5ResourceType.Patient,
         fhirId: '12345',
         vid: FhirId('6789'),
+        format: mimeType,
         pretty: true,
         summary: Summary.true_,
       );
@@ -164,6 +176,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         vid: FhirId('6789'),
         summary: Summary.count,
       );
@@ -183,6 +197,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.transaction(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         bundle: bundle,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -200,6 +216,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -214,6 +232,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.historyType(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -227,6 +247,8 @@ Future<void> fhirUriTest() async {
     test('history for everything', () async {
       final FhirRequest request = FhirRequest.historyAll(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -247,6 +269,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         parameters: parameters,
       );
 
@@ -267,6 +291,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.update(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -284,6 +310,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.patch(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -301,6 +329,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -318,6 +348,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.create(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -334,6 +366,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.capabilities(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         mode: Mode.normative,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -356,6 +390,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         operation: 'everything',
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -376,6 +412,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '744742',
+        format: mimeType,
+        pretty: false,
         operation: 'everything',
         parameters: parameters,
       );
@@ -397,6 +435,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
+        format: mimeType,
+        pretty: false,
         parameters: <String>['_id=12345'],
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -412,6 +452,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
+        format: mimeType,
+        pretty: false,
         restfulRequest: RestfulRequest.post_,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -428,6 +470,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.search(
           base: Uri.parse('http://hapi.fhir.org/baseR5'),
           type: R5ResourceType.Observation,
+          format: mimeType,
+          pretty: false,
           parameters: parameters);
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -446,6 +490,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Condition,
+        format: mimeType,
+        pretty: false,
         parameters: parameters,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
@@ -466,6 +512,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.DiagnosticReport,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -483,6 +531,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -500,6 +550,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -517,6 +569,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -534,6 +588,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -550,6 +606,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.RiskAssessment,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -569,6 +627,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -590,6 +650,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -611,6 +673,8 @@ Future<void> fhirUriTest() async {
       final FhirRequest request = FhirRequest.searchAll(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -630,6 +694,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -647,6 +713,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Composition,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -666,6 +734,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Condition,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -685,6 +755,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -704,6 +776,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -723,6 +797,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -742,6 +818,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,
@@ -759,6 +837,8 @@ Future<void> fhirUriTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       expect(request, FhirRequest.fromJson(request.toJson()));
       expect(request.runtimeType,

--- a/test/r5/http_request_tests.dart
+++ b/test/r5/http_request_tests.dart
@@ -5,13 +5,15 @@ import 'package:fhir/r5.dart';
 import 'package:fhir_at_rest/r5.dart';
 import 'package:test/test.dart';
 
-void httpRequestTests()  {
+void httpRequestTests() {
   group('FhirRequest - READ:', () {
-    test('get patient', ()  {
+    test('get patient', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -27,11 +29,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient with pretty', ()  {
+    test('get patient with pretty', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
         pretty: true,
       );
       final FhirHttpRequest fhirHttpRequest = request
@@ -49,11 +52,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient with pretty and summary true', ()  {
+    test('get patient with pretty and summary true', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
         pretty: true,
         summary: Summary.true_,
       );
@@ -72,11 +76,13 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient with summary count', ()  {
+    test('get patient with summary count', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
         summary: Summary.count,
       );
       final FhirHttpRequest fhirHttpRequest = request
@@ -94,11 +100,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient  with pretty, only want to return name', ()  {
+    test('get patient  with pretty, only want to return name', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '1227442',
+        format: 'json',
         pretty: true,
         elements: <String>['name'],
       );
@@ -117,12 +124,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient with pretty, only want to return name and gender',
-        ()  {
+    test('get patient with pretty, only want to return name and gender', () {
       final FhirRequest request = FhirRequest.read(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '1227442',
+        format: 'json',
         pretty: true,
         elements: <String>['name', 'gender'],
       );
@@ -143,11 +150,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'read']);
 
   group('FhirRequest - VREAD:', () {
-    test('get patient version', ()  {
+    test('get patient version', () {
       final FhirRequest request = FhirRequest.vRead(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
         vid: FhirId('6789'),
       );
       final FhirHttpRequest fhirHttpRequest = request
@@ -165,11 +174,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient version with pretty', ()  {
+    test('get patient version with pretty', () {
       final FhirRequest request = FhirRequest.vRead(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
         vid: FhirId('6789'),
         pretty: true,
       );
@@ -188,11 +198,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient version with pretty and summary true', ()  {
+    test('get patient version with pretty and summary true', () {
       final FhirRequest request = FhirRequest.vRead(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
         vid: FhirId('6789'),
         pretty: true,
         summary: Summary.true_,
@@ -212,11 +223,13 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('get patient version with summary count', ()  {
+    test('get patient version with summary count', () {
       final FhirRequest request = FhirRequest.vRead(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
         vid: FhirId('6789'),
         summary: Summary.count,
       );
@@ -237,7 +250,7 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'vread']);
 
   group('FhirRequest - TRANSACTION:', () {
-    test('transaction/batch', ()  {
+    test('transaction/batch', () {
       final Bundle bundle = Bundle(
           type: FhirCode('transaction'),
           fhirId: FhirId('12345'),
@@ -250,6 +263,8 @@ void httpRequestTests()  {
       final FhirRequest request = FhirRequest.transaction(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         bundle: bundle,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -267,7 +282,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('batch with error in bundle', ()  {
+    test('batch with error in bundle', () {
       final Bundle bundle = Bundle(
           type: FhirCode('batch'),
           fhirId: FhirId('12345'),
@@ -275,6 +290,8 @@ void httpRequestTests()  {
       final FhirRequest request = FhirRequest.batch(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         bundle: bundle,
+        format: 'json',
+        pretty: false,
       );
       try {
         request.toFhirHttpRequest(headers: <String, String>{'test': 'header'});
@@ -288,11 +305,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'transaction']);
 
   group('FhirRequest - HISTORY:', () {
-    test('observation history by type and id', ()  {
+    test('observation history by type and id', () {
       final FhirRequest request = FhirRequest.history(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -309,10 +328,12 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation history by type', ()  {
+    test('observation history by type', () {
       final FhirRequest request = FhirRequest.historyType(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -329,9 +350,11 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('history for everything', ()  {
+    test('history for everything', () {
       final FhirRequest request = FhirRequest.historyAll(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -349,7 +372,7 @@ void httpRequestTests()  {
     });
 
     test('history resource by type and id, count of 10, after a specified date',
-        ()  {
+        () {
       final List<String> parameters = <String>[
         '_count=10',
         '_since=2020-10-08T16:58:07.241117Z',
@@ -358,6 +381,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
         parameters: parameters,
       );
 
@@ -378,10 +403,12 @@ void httpRequestTests()  {
 
     test(
         'search all history, count = 10, since 2020-10-08, and only '
-        'those that are included in the List/12345', ()  {
+        'those that are included in the List/12345', () {
       final FhirRequest request = FhirRequest.historyAll(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         reference: 'List/12345',
+        format: 'json',
+        pretty: false,
         parameters: <String>['_count=10', '_since=2020-10-08'],
       );
       final FhirHttpRequest fhirHttpRequest = request
@@ -401,11 +428,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'history']);
 
   group('FhirRequest - UPDATE:', () {
-    test('update patient by id', ()  {
+    test('update patient by id', () {
       final Patient patient = Patient(fhirId: FhirId('12345'));
       final FhirRequest request = FhirRequest.update(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         resource: patient,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -426,11 +455,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'update']);
 
   group('FhirRequest - PATCH:', () {
-    test('patch patient by id', ()  {
+    test('patch patient by id', () {
       final Patient patient = Patient(fhirId: FhirId('12345'));
       final FhirRequest request = FhirRequest.patch(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         resource: patient,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -451,11 +482,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'patch']);
 
   group('FhirRequest - DELETE:', () {
-    test('delete patient', ()  {
+    test('delete patient', () {
       final FhirRequest request = FhirRequest.delete(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -474,11 +507,13 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'delete']);
 
   group('FhirRequest - CREATE:', () {
-    test('create patient', ()  {
+    test('create patient', () {
       final Patient patient = Patient(fhirId: FhirId('12345'));
       final FhirRequest request = FhirRequest.create(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         resource: patient,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -498,10 +533,12 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'create']);
 
   group('FhirRequest - CAPABILITIES:', () {
-    test('capabilities with mode normative', ()  {
+    test('capabilities with mode normative', () {
       final FhirRequest request = FhirRequest.capabilities(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         mode: Mode.normative,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -520,7 +557,7 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'capabilities']);
 
   group('FhirRequest - OPERATION:', () {
-    test(r'$everything operation', ()  {
+    test(r'$everything operation', () {
       final List<String> parameters = <String>[
         'start=2020-01-01',
         'end=2020-08-01'
@@ -529,6 +566,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         operation: 'everything',
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -545,7 +584,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test(r'$everything operation for Patient 744742', ()  {
+    test(r'$everything operation for Patient 744742', () {
       final List<String> parameters = <String>[
         'start=2020-01-01',
         'end=2020-08-01'
@@ -556,6 +595,8 @@ void httpRequestTests()  {
         fhirId: '744742',
         operation: 'everything',
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
 
       final FhirHttpRequest fhirHttpRequest = request
@@ -575,12 +616,14 @@ void httpRequestTests()  {
   }, tags: <String>['uri', 'operation']);
 
   group('FhirRequest - SEARCH:', () {
-    test('patient id search', ()  {
+    test('patient id search', () {
       final List<String> parameters = <String>['_id=12345'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -597,11 +640,13 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient id search using post', ()  {
+    test('patient id search using post', () {
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         restfulRequest: RestfulRequest.post_,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -618,12 +663,15 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation time search', ()  {
+    test('observation time search', () {
       final List<String> parameters = <String>['_lastUpdated=gt2010-10-01'];
       final FhirRequest request = FhirRequest.search(
-          base: Uri.parse('http://hapi.fhir.org/baseR5'),
-          type: R5ResourceType.Observation,
-          parameters: parameters);
+        base: Uri.parse('http://hapi.fhir.org/baseR5'),
+        type: R5ResourceType.Observation,
+        parameters: parameters,
+        format: 'json',
+        pretty: false,
+      );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
 
@@ -639,7 +687,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('condition search, code parameter (_tag)', ()  {
+    test('condition search, code parameter (_tag)', () {
       final List<String> parameters = <String>[
         '_tag=http://acme.org/codes|needs-review'
       ];
@@ -647,6 +695,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Condition,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -663,7 +713,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('diagnostic report rearch, uri parameter (_profile)', ()  {
+    test('diagnostic report rearch, uri parameter (_profile)', () {
       final List<String> parameters = <String>[
         '_profile=http://acme.org/codes'
       ];
@@ -671,6 +721,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.DiagnosticReport,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -687,12 +739,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search if gender present', ()  {
+    test('patient search if gender present', () {
       final List<String> parameters = <String>['gender:missing=true'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -709,12 +763,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search if gender present', ()  {
+    test('patient search if gender present', () {
       final List<String> parameters = <String>['gender:missing=false'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -731,12 +787,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search for exact text match', ()  {
+    test('patient search for exact text match', () {
       final List<String> parameters = <String>['_text:exact=Stark'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -753,12 +811,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation search "le"', ()  {
+    test('observation search "le"', () {
       final List<String> parameters = <String>['_lastUpdated=le2010-10-01'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -775,12 +835,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('risk assessment search, probability > 0.8', ()  {
+    test('risk assessment search, probability > 0.8', () {
       final List<String> parameters = <String>['probability=gt0.8'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.RiskAssessment,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -797,7 +859,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search for birthday between two dates', ()  {
+    test('patient search for birthday between two dates', () {
       final List<String> parameters = <String>[
         'birthdate=ge2010-01-01',
         'birthdate=le2011-12-31',
@@ -806,6 +868,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -822,7 +886,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search given name with parameters', ()  {
+    test('patient search given name with parameters', () {
       final List<String> parameters = <String>[
         'given=eve',
         'given:contains=eve',
@@ -832,6 +896,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -848,7 +914,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search given name with parameters', ()  {
+    test('patient search given name with parameters', () {
       final List<String> parameters = <String>[
         '_type=Patient',
         'given=eve',
@@ -858,6 +924,8 @@ void httpRequestTests()  {
       final FhirRequest request = FhirRequest.searchAll(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -874,7 +942,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search with identifier', ()  {
+    test('patient search with identifier', () {
       final List<String> parameters = <String>[
         'identifier=http://acme.org/patient|2345'
       ];
@@ -882,6 +950,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -898,12 +968,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('composition search section code', ()  {
+    test('composition search section code', () {
       final List<String> parameters = <String>['section:not=48765-2'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Composition,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -920,7 +992,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('condition search via snomed code', ()  {
+    test('condition search via snomed code', () {
       final List<String> parameters = <String>[
         'code:in=http://snomed.info/sct?fhir_vs=isa/126851005'
       ];
@@ -928,6 +1000,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Condition,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -944,7 +1018,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('patient search by mr code', ()  {
+    test('patient search by mr code', () {
       final List<String> parameters = <String>[
         'identifier:of-type=http://terminology.hl7.org/CodeSystem/v2-0203|MR|446053'
       ];
@@ -952,6 +1026,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -968,7 +1044,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation search by quantity, with prefix', ()  {
+    test('observation search by quantity, with prefix', () {
       final List<String> parameters = <String>[
         'value-quantity=ap5.4|http://unitsofmeasure.org|mg'
       ];
@@ -976,6 +1052,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -992,7 +1070,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation search by quantity, without prefix', ()  {
+    test('observation search by quantity, without prefix', () {
       final List<String> parameters = <String>[
         'value-quantity=5.4|http://unitsofmeasure.org|mg'
       ];
@@ -1000,6 +1078,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -1016,7 +1096,7 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation search by quantity, testing number parsing', ()  {
+    test('observation search by quantity, testing number parsing', () {
       final List<String> parameters = <String>[
         'value-quantity=0.0054|http://unitsofmeasure.org|g'
       ];
@@ -1024,6 +1104,8 @@ void httpRequestTests()  {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});
@@ -1040,12 +1122,14 @@ void httpRequestTests()  {
       expect(fhirHttpRequest.toJson(), requestMap);
     });
 
-    test('observation search by reference, using url', ()  {
+    test('observation search by reference, using url', () {
       final List<String> parameters = <String>['subject=Patient/123'];
       final FhirRequest request = FhirRequest.search(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: 'json',
+        pretty: false,
       );
       final FhirHttpRequest fhirHttpRequest = request
           .toFhirHttpRequest(headers: <String, String>{'test': 'headers'});

--- a/test/r5/requests_test.dart
+++ b/test/r5/requests_test.dart
@@ -16,6 +16,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -34,6 +36,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         pretty: true,
       );
       final OperationOutcome? response =
@@ -53,6 +56,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         pretty: true,
         summary: Summary.true_,
       );
@@ -73,6 +77,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         summary: Summary.count,
       );
       final OperationOutcome? response =
@@ -92,6 +98,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '1227442',
+        format: mimeType,
         pretty: true,
         elements: <String>['name'],
       );
@@ -113,6 +120,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '1227442',
+        format: mimeType,
         pretty: true,
         elements: <String>['name', 'gender'],
       );
@@ -135,6 +143,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         vid: FhirId('6789'),
       );
       final OperationOutcome? response =
@@ -154,6 +164,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         vid: FhirId('6789'),
         pretty: true,
       );
@@ -174,6 +185,7 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
         vid: FhirId('6789'),
         pretty: true,
         summary: Summary.true_,
@@ -195,6 +207,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
         vid: FhirId('6789'),
         summary: Summary.count,
       );
@@ -225,6 +239,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.transaction(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         bundle: bundle,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -246,6 +262,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.batch(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         bundle: bundle,
+        format: mimeType,
+        pretty: false,
       );
       try {
         final OperationOutcome? response =
@@ -270,6 +288,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -287,6 +307,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.historyType(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -303,6 +325,8 @@ Future<void> requestsTest() async {
     test('history for everything', () async {
       final FhirRequest request = FhirRequest.historyAll(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -327,6 +351,8 @@ Future<void> requestsTest() async {
         type: R5ResourceType.Observation,
         fhirId: '12345',
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
 
       final OperationOutcome? response =
@@ -349,6 +375,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         reference: 'List/12345',
         parameters: <String>['_count=10', '_since=2020-10-08'],
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -370,6 +398,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.update(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -390,6 +420,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.patch(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -410,6 +442,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         fhirId: '12345',
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -430,6 +464,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.create(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         resource: patient,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -449,6 +485,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.capabilities(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         mode: Mode.normative,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -474,6 +512,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         operation: 'everything',
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -499,6 +539,8 @@ Future<void> requestsTest() async {
         fhirId: '744742',
         operation: 'everything',
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
 
       final OperationOutcome? response =
@@ -522,6 +564,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -540,6 +584,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         restfulRequest: RestfulRequest.post_,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -558,6 +604,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.search(
           base: Uri.parse('http://hapi.fhir.org/baseR5'),
           type: R5ResourceType.Observation,
+          format: mimeType,
+          pretty: false,
           parameters: parameters);
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -580,6 +628,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Condition,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -602,6 +652,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.DiagnosticReport,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -622,6 +674,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -642,6 +696,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -662,6 +718,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -682,6 +740,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -701,6 +761,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.RiskAssessment,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -723,6 +785,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -747,6 +811,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -771,6 +837,8 @@ Future<void> requestsTest() async {
       final FhirRequest request = FhirRequest.searchAll(
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -793,6 +861,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -813,6 +883,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Composition,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -835,6 +907,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Condition,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -857,6 +931,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Patient,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -879,6 +955,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -901,6 +979,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -923,6 +1003,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})
@@ -943,6 +1025,8 @@ Future<void> requestsTest() async {
         base: Uri.parse('http://hapi.fhir.org/baseR5'),
         type: R5ResourceType.Observation,
         parameters: parameters,
+        format: mimeType,
+        pretty: false,
       );
       final OperationOutcome? response =
           await request.request(headers: <String, String>{'test': 'headers'})


### PR DESCRIPTION
Hi, first of all thanks for this amazing package 👌.

This PR is only to make the general parameters `_format` and `pretty` optional, so the request doesn't include these params unless the dev states it.
The idea is to keep the request as simple as possible having only what's necessary, moreover most of the FHIR backends _(if not all)_ already uses json responses by default, so no need to specify it, it should be enough to state in the documentation that this package doesn't support XML.
By the way I recently  had a bad experience with **Medplum API** which didn't support `_format` nor `_pretty` general params and the requests were `bad request error 400`, check here: [Medplum #3975](https://github.com/medplum/medplum/issues/3975), despite they already fixed it, I still consider letting these params as optional is better.

I leave it for your consideration.